### PR TITLE
fix(basic-web): document multi OAuth constraints and Docker build deps

### DIFF
--- a/examples/basic-web/AGENTS.md
+++ b/examples/basic-web/AGENTS.md
@@ -23,6 +23,7 @@
 - `src/client/hooks/chat-history.ts` is in charge of pure conversion logic for history restoration (history → UI events), and `useChat` is in charge of run restart judgment and SSE subscription control.
 - `loadHistory` of `src/client/hooks/useChat.ts` re-detects the active run in `GET /api/runs?session_id=...&statuses=queued,running&limit=1` and automatically resumes SSE resubscription even after reload (if necessary, complete `input_text` on the user side).
 - Use `docker-compose.multi.yml` (single file) for multiple startup verification under LB (Traefik front stage + `--scale api=2 --scale worker=2`, Traefik settings are `traefik/dynamic.yml`).
+- `docker-compose.multi.yml` always enables public OAuth callback (`http://localhost:${API_PORT:-3001}`); if OAuth fails there, connect once via single profile loopback (`docker-compose.yml` + `http://localhost:1455/auth/callback`) and reuse the same Postgres volume.
 - Server `src/server/routes/chat.ts` monitors `c.req.raw.signal` and aborts the run when disconnected.
 - Since `src/server/routes/chat.ts` outputs request lifecycle logs (start/first event/done/error/finish), give priority to server logs when isolating connection problems.
 - Authentication/model settings are managed by `src/server/routes/settings.ts` (`/api/settings`) and `src/server/settings/settings-store.ts`. When updating the settings, use `AgentPool.invalidateAll()` to discard the existing agent and apply the new settings from the next run.
@@ -37,6 +38,7 @@
 - The status strip under the Chat header displays the run status and execution time (in progress/recently completed).
 - `POST /api/sessions` immediately saves an empty session. `new chat` Do not remove this save to avoid a problem where you cannot list/restore it later.
 - `SessionManager.delete` physically deletes the state file. Behavior that deletes the entity rather than hiding it on display.
+- `examples/basic-web/Dockerfile` installs `build-essential` because `better-sqlite3` may compile from source during `bun install` in container builds.
 
 ## Local Dev
 - `cd examples/basic-web && bun run dev`

--- a/examples/basic-web/Dockerfile
+++ b/examples/basic-web/Dockerfile
@@ -1,9 +1,10 @@
-FROM oven/bun:1.3.8
+FROM oven/bun:1.3.9
 
 WORKDIR /workspace
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
+    build-essential \
     python3 \
     python3-pip \
   && rm -rf /var/lib/apt/lists/*

--- a/examples/basic-web/README.md
+++ b/examples/basic-web/README.md
@@ -97,6 +97,8 @@ This starts:
 
 Notes:
 - In this profile, OAuth uses public callback mode via `http://localhost:3001` (through Traefik).
+- `docker-compose.multi.yml` fixes `CODELIA_OPENAI_OAUTH_PUBLIC_BASE_URL` to `http://localhost:${API_PORT:-3001}`, so loopback callback (`http://localhost:1455/auth/callback`) is not used in this profile.
+- With the built-in default OpenAI OAuth client id, public callback authorization may fail depending on redirect URI policy. If OAuth login fails in multi profile, connect OAuth once in single profile (`docker-compose.yml`, loopback callback), then switch back to multi while keeping the same Postgres volume.
 - If host `5432` is occupied, use `POSTGRES_PORT=55432`.
 - This profile is a standalone compose file (do not combine with `docker-compose.yml`).
 


### PR DESCRIPTION
## Summary
- update `examples/basic-web/Dockerfile` to use Bun `1.3.9` and install `build-essential` so native modules (e.g. `better-sqlite3`) can build in Docker
- document that `docker-compose.multi.yml` uses public OAuth callback mode and does not use loopback callback
- add fallback guidance: run OAuth once in single-profile loopback mode, then switch back to multi profile with the same Postgres volume
- sync the same operational note into `examples/basic-web/AGENTS.md`

## Verification
- confirmed OAuth start endpoint returns redirect with public callback in multi-profile (`/api/settings/openai/oauth/start`)
- no code-path changes beyond Docker image dependencies and docs