### PR TITLE
Implement approval mode precedence + projects policy store

### DIFF
--- a/crates/tui/src/app/runtime/client.rs
+++ b/crates/tui/src/app/runtime/client.rs
@@ -65,11 +65,16 @@ fn spawn_reader<T: std::io::Read + Send + 'static>(
     });
 }
 
-pub fn spawn_runtime(enable_diagnostics: bool) -> RuntimeSpawnResult {
+pub fn spawn_runtime(enable_diagnostics: bool, approval_mode: Option<&str>) -> RuntimeSpawnResult {
     let runtime_cmd = env::var("CODELIA_RUNTIME_CMD").unwrap_or_else(|_| "bun".to_string());
-    let runtime_args = env::var("CODELIA_RUNTIME_ARGS")
+    let mut runtime_args = env::var("CODELIA_RUNTIME_ARGS")
         .map(|value| split_args(&value))
         .unwrap_or_else(|_| vec!["packages/runtime/src/index.ts".to_string()]);
+
+    if let Some(mode) = approval_mode {
+        runtime_args.push("--approval-mode".to_string());
+        runtime_args.push(mode.to_string());
+    }
 
     let mut command = Command::new(runtime_cmd);
     command

--- a/docs/specs/approval-mode.md
+++ b/docs/specs/approval-mode.md
@@ -49,7 +49,8 @@ Resolved in this order (highest first):
 5. Startup selection flow (first-time setup, UI-capable clients only)
 6. Built-in fallback: `minimal`
 
-Invalid values in any source are ignored and resolution continues to lower priority.
+Invalid values in CLI/env/policy sources are treated as explicit errors.
+Resolution does not silently continue to lower priority when an invalid value is present.
 
 ---
 
@@ -86,7 +87,8 @@ Rules:
 ### 5.2 Write requirements
 
 1. Create parent directory if missing.
-2. Write with `0600` permission where supported.
+2. Write with `0600` permission.
+   - On non-Windows platforms, chmod failures are surfaced as errors (not ignored).
 3. Use atomic write (temp file + rename).
 4. Never write this file from model tool execution paths (`read`/`write`/`edit`/`bash`).
    - Update is only via runtime-owned settings path (startup flow and future explicit CLI command).
@@ -111,11 +113,11 @@ If normalization fails, fallback to resolved absolute path without symlink expan
 `approval_mode` affects only the pre-execution decision gate:
 
 - `minimal` and `trusted`: existing `deny > allow > confirm` flow remains.
-- `full-access`: return `allow` immediately for tool execution gate.
+- `full-access`: skip `confirm` and return `allow` for non-denied tool execution.
 
 Notes:
 
-- Existing explicit deny rules still apply if runtime keeps deny checks enabled before mode short-circuit.
+- Existing explicit deny rules still apply in `full-access`.
 - Mode naming does not imply OS sandbox strength.
 
 ---

--- a/docs/specs/permissions.md
+++ b/docs/specs/permissions.md
@@ -35,7 +35,9 @@ OS-level containment remains a separate `sandbox backend` concern.
 
 - `minimal` (default): keep the current minimum system allowlist (read-oriented), and route everything else to `confirm`.
 - `trusted`: include additional write-oriented rules in system allowlist (workspace-scoped), while still using `confirm` for anything not explicitly allowed.
-- `full-access`: no `confirm` gate (intended for unattended benchmark/CI usage).
+  - Current trusted additions include tool `write`/`edit` and bash commands `sed`/`awk`.
+- `full-access`: no `confirm` gate for non-denied operations (intended for unattended benchmark/CI usage).
+  - Explicit `deny` rules are still enforced.
 
 > Note: Detailed precedence and storage design are defined in `docs/specs/approval-mode.md`.
 
@@ -219,6 +221,13 @@ The following allows **command**:
 
 `cd` is not a command allowlist and is automatically allowed by runtime only if there is no deviation from the sandbox.
 Confirm `cd` to exit the sandbox.
+
+### 7.3 trusted additions
+
+When `approval_mode=trusted`, system allowlist is extended with:
+
+- tools: `write`, `edit`
+- bash: `sed`, `awk`
 
 ---
 

--- a/packages/cli/src/basic-options.ts
+++ b/packages/cli/src/basic-options.ts
@@ -15,6 +15,7 @@ export const TOP_LEVEL_HELP_TEXT = [
 	"  --initial-message <text>",
 	"  --initial-user-message <text>",
 	"  --debug-perf[=true|false]",
+	"  --approval-mode <minimal|trusted|full-access>",
 ].join("\n");
 
 const isHelpFlag = (value: string): boolean =>

--- a/packages/cli/src/tui/launcher.ts
+++ b/packages/cli/src/tui/launcher.ts
@@ -30,6 +30,7 @@ const splitArgs = (value: string): string[] =>
 const quoteShellWord = (value: string): string =>
 	`'${value.replace(/'/g, "'\\''")}'`;
 
+
 const isExecutable = (candidate: string): boolean => {
 	try {
 		fsSync.accessSync(candidate, fsSync.constants.X_OK);

--- a/packages/cli/tests/basic-options.test.ts
+++ b/packages/cli/tests/basic-options.test.ts
@@ -35,6 +35,7 @@ describe("TOP_LEVEL_HELP_TEXT", () => {
 		expect(TOP_LEVEL_HELP_TEXT).toContain("--version");
 		expect(TOP_LEVEL_HELP_TEXT).toContain("--resume");
 		expect(TOP_LEVEL_HELP_TEXT).toContain("--diagnostics");
+		expect(TOP_LEVEL_HELP_TEXT).toContain("--approval-mode");
 		expect(TOP_LEVEL_HELP_TEXT).toContain("mcp");
 	});
 });

--- a/packages/cli/tests/runtime-launcher.test.ts
+++ b/packages/cli/tests/runtime-launcher.test.ts
@@ -49,6 +49,7 @@ describe("resolveRuntimeEnvForTui", () => {
 		expect(resolved.CODELIA_RUNTIME_CMD).toBeUndefined();
 		expect(resolved.CODELIA_RUNTIME_ARGS).toBeUndefined();
 	});
+
 });
 
 describe("resolveLaunchEnvForTui", () => {

--- a/packages/core/src/di/storage.ts
+++ b/packages/core/src/di/storage.ts
@@ -6,6 +6,7 @@ export type StoragePaths = {
 	configFile: string;
 	authFile: string;
 	mcpAuthFile: string;
+	projectsFile: string;
 	cacheDir: string;
 	toolOutputCacheDir: string;
 	sessionsDir: string;

--- a/packages/runtime/AGENTS.md
+++ b/packages/runtime/AGENTS.md
@@ -48,6 +48,11 @@ Save session resume state via `@codelia/storage` (`sessions/state.db` index +
 restore with `run.start.session_id` (history is snapshot at the end of run).
 `session.history` resends `agent.event` of the past run, and TUI redraws the history.
 Before running the tool, determine permission and obtain approval using UI confirm (allowlist/denylist is `permissions` in config).
+`trusted` extends system allowlist with workspace write tools (`write`/`edit`) and bash commands (`sed`/`awk`).
+Approval mode is resolved in runtime with precedence `--approval-mode` flag > `CODELIA_APPROVAL_MODE` > global `projects.json` project entry > global `projects.json` default > fallback `minimal`.
+Invalid approval-mode values from CLI/env are surfaced as explicit errors (not silently ignored).
+`projects.json` is loaded from storage config dir (`~/.codelia/projects.json` or XDG config equivalent) and keyed by normalized sandbox root/project path.
+If `projects.json` is malformed/invalid, runtime surfaces an explicit load error (no silent fallback).
 When logging permission preflight context, flush those `agent.event` messages before sending `ui.confirm.request` so UI history is rendered before the modal confirm appears (legacy raw-args JSON text is not emitted; use structured `permission.preview`/`permission.ready` events).
 Runtime emits structured permission preflight events (`permission.preview` / `permission.ready`) before `ui.confirm.request` and does not emit the legacy text preflight format.
 `permission.preview` can include `language` (preferred) and `file_path` so UI can infer syntax even when diff headers are missing/truncated.

--- a/packages/runtime/src/permissions/approval-mode.ts
+++ b/packages/runtime/src/permissions/approval-mode.ts
@@ -1,0 +1,142 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { parseApprovalMode, type ApprovalMode } from "@codelia/shared-types";
+import { ProjectsPolicyStore } from "@codelia/storage";
+
+const normalizePath = async (value: string): Promise<string> => {
+	const absolute = path.resolve(value);
+	try {
+		return await fs.realpath(absolute);
+	} catch {
+		return absolute;
+	}
+};
+
+export const resolveProjectPolicyKey = async (
+	workingDir: string,
+	runtimeSandboxRoot?: string | null,
+): Promise<string> => {
+	const basePath = runtimeSandboxRoot ?? workingDir;
+	return normalizePath(basePath);
+};
+
+const APPROVAL_MODE_HINT = "minimal|trusted|full-access";
+
+const parseApprovalModeOrThrow = (
+	raw: string | undefined,
+	source: string,
+): ApprovalMode => {
+	if (!raw || raw.trim().length === 0) {
+		throw new Error(
+			`Invalid ${source}: missing value (expected ${APPROVAL_MODE_HINT})`,
+		);
+	}
+	const parsed = parseApprovalMode(raw);
+	if (!parsed) {
+		throw new Error(
+			`Invalid ${source}: '${raw}' (expected ${APPROVAL_MODE_HINT})`,
+		);
+	}
+	return parsed;
+};
+
+const resolveCliApprovalModeOrThrow = (
+	args: string[],
+): ApprovalMode | undefined => {
+	for (let i = 0; i < args.length; i += 1) {
+		const current = args[i];
+		if (!current.startsWith("--approval-mode")) continue;
+		if (current === "--approval-mode") {
+			return parseApprovalModeOrThrow(args[i + 1], "--approval-mode");
+		}
+		if (current.startsWith("--approval-mode=")) {
+			return parseApprovalModeOrThrow(
+				current.slice("--approval-mode=".length),
+				"--approval-mode",
+			);
+		}
+	}
+	return undefined;
+};
+
+const resolveEnvApprovalModeOrThrow = (
+	env: NodeJS.ProcessEnv,
+): ApprovalMode | undefined => {
+	if (env.CODELIA_APPROVAL_MODE === undefined) {
+		return undefined;
+	}
+	return parseApprovalModeOrThrow(
+		env.CODELIA_APPROVAL_MODE,
+		"CODELIA_APPROVAL_MODE",
+	);
+};
+
+const resolvePolicyApprovalMode = (
+	policy: Awaited<ReturnType<ProjectsPolicyStore["load"]>>,
+	projectKey: string,
+): { approvalMode: ApprovalMode; source: "project" | "default" } | undefined => {
+	if (!policy) {
+		return undefined;
+	}
+	const projectMode = parseApprovalMode(policy.projects?.[projectKey]?.approval_mode);
+	if (projectMode) {
+		return { approvalMode: projectMode, source: "project" };
+	}
+	const defaultMode = parseApprovalMode(policy.default?.approval_mode);
+	if (defaultMode) {
+		return { approvalMode: defaultMode, source: "default" };
+	}
+	return undefined;
+};
+
+const loadProjectsPolicyOrThrow = async (
+	store: ProjectsPolicyStore,
+): Promise<Awaited<ReturnType<ProjectsPolicyStore["load"]>>> => {
+	try {
+		return await store.load();
+	} catch (error) {
+		const detail = error instanceof Error ? error.message : String(error);
+		throw new Error(
+			`Failed to load approval mode policy (${store.getFilePath()}): ${detail}`,
+		);
+	}
+};
+
+export const resolveApprovalModeForRuntime = async (options: {
+	workingDir: string;
+	runtimeSandboxRoot?: string | null;
+}): Promise<{
+	approvalMode: ApprovalMode;
+	source: "cli" | "env" | "project" | "default" | "fallback";
+	projectKey: string;
+}> => {
+	const projectKey = await resolveProjectPolicyKey(
+		options.workingDir,
+		options.runtimeSandboxRoot,
+	);
+
+	const cliMode = resolveCliApprovalModeOrThrow(process.argv.slice(2));
+	if (cliMode) {
+		return { approvalMode: cliMode, source: "cli", projectKey };
+	}
+
+	const envMode = resolveEnvApprovalModeOrThrow(process.env);
+	if (envMode) {
+		return { approvalMode: envMode, source: "env", projectKey };
+	}
+
+	const store = new ProjectsPolicyStore();
+	const policyMode = resolvePolicyApprovalMode(
+		await loadProjectsPolicyOrThrow(store),
+		projectKey,
+	);
+	if (policyMode) {
+		return {
+			approvalMode: policyMode.approvalMode,
+			source: policyMode.source,
+			projectKey,
+		};
+	}
+
+	return { approvalMode: "minimal", source: "fallback", projectKey };
+};

--- a/packages/runtime/tests/approval-mode.test.ts
+++ b/packages/runtime/tests/approval-mode.test.ts
@@ -1,0 +1,263 @@
+import { describe, expect, test } from "bun:test";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { resolveStoragePaths } from "@codelia/storage";
+import {
+	resolveApprovalModeForRuntime,
+	resolveProjectPolicyKey,
+} from "../src/permissions/approval-mode";
+
+const withTempStorageEnv = async () => {
+	const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "codelia-approval-"));
+	const restore: Array<[string, string | undefined]> = [];
+	const setEnv = (key: string, value: string) => {
+		restore.push([key, process.env[key]]);
+		process.env[key] = value;
+	};
+	setEnv("CODELIA_LAYOUT", "xdg");
+	setEnv("XDG_STATE_HOME", path.join(tempRoot, "state"));
+	setEnv("XDG_CACHE_HOME", path.join(tempRoot, "cache"));
+	setEnv("XDG_CONFIG_HOME", path.join(tempRoot, "config"));
+	setEnv("XDG_DATA_HOME", path.join(tempRoot, "data"));
+
+	const projectDir = path.join(tempRoot, "workspace", "repo");
+	await fs.mkdir(projectDir, { recursive: true });
+
+	return {
+		tempRoot,
+		projectDir,
+		cleanup: async () => {
+			for (const [key, value] of restore.reverse()) {
+				if (value === undefined) {
+					delete process.env[key];
+				} else {
+					process.env[key] = value;
+				}
+			}
+			await fs.rm(tempRoot, { recursive: true, force: true });
+		},
+	};
+};
+
+const withArgv = async (argv: string[], run: () => Promise<void>) => {
+	const original = [...process.argv];
+	process.argv = argv;
+	try {
+		await run();
+	} finally {
+		process.argv = original;
+	}
+};
+
+describe("approval mode resolution", () => {
+	test("falls back to minimal when no source is configured", async () => {
+		const env = await withTempStorageEnv();
+		try {
+			const result = await resolveApprovalModeForRuntime({
+				workingDir: env.projectDir,
+				runtimeSandboxRoot: env.projectDir,
+			});
+			expect(result.approvalMode).toBe("minimal");
+			expect(result.source).toBe("fallback");
+		} finally {
+			await env.cleanup();
+		}
+	});
+
+	test("uses env mode when cli flag is missing", async () => {
+		const env = await withTempStorageEnv();
+		const previous = process.env.CODELIA_APPROVAL_MODE;
+		process.env.CODELIA_APPROVAL_MODE = "trusted";
+		try {
+			const result = await resolveApprovalModeForRuntime({
+				workingDir: env.projectDir,
+				runtimeSandboxRoot: env.projectDir,
+			});
+			expect(result.approvalMode).toBe("trusted");
+			expect(result.source).toBe("env");
+		} finally {
+			if (previous === undefined) {
+				delete process.env.CODELIA_APPROVAL_MODE;
+			} else {
+				process.env.CODELIA_APPROVAL_MODE = previous;
+			}
+			await env.cleanup();
+		}
+	});
+
+	test("throws explicit error for invalid env approval mode", async () => {
+		const env = await withTempStorageEnv();
+		const previous = process.env.CODELIA_APPROVAL_MODE;
+		process.env.CODELIA_APPROVAL_MODE = "danger";
+		try {
+			await expect(
+				resolveApprovalModeForRuntime({
+					workingDir: env.projectDir,
+					runtimeSandboxRoot: env.projectDir,
+				}),
+			).rejects.toThrow("Invalid CODELIA_APPROVAL_MODE");
+		} finally {
+			if (previous === undefined) {
+				delete process.env.CODELIA_APPROVAL_MODE;
+			} else {
+				process.env.CODELIA_APPROVAL_MODE = previous;
+			}
+			await env.cleanup();
+		}
+	});
+
+	test("cli flag has highest precedence", async () => {
+		const env = await withTempStorageEnv();
+		const previous = process.env.CODELIA_APPROVAL_MODE;
+		process.env.CODELIA_APPROVAL_MODE = "minimal";
+		try {
+			await withArgv(
+				["node", "runtime", "--approval-mode", "full-access"],
+				async () => {
+					const result = await resolveApprovalModeForRuntime({
+						workingDir: env.projectDir,
+						runtimeSandboxRoot: env.projectDir,
+					});
+					expect(result.approvalMode).toBe("full-access");
+					expect(result.source).toBe("cli");
+				},
+			);
+		} finally {
+			if (previous === undefined) {
+				delete process.env.CODELIA_APPROVAL_MODE;
+			} else {
+				process.env.CODELIA_APPROVAL_MODE = previous;
+			}
+			await env.cleanup();
+		}
+	});
+
+	test("throws explicit error for invalid cli approval mode", async () => {
+		const env = await withTempStorageEnv();
+		try {
+			await withArgv(
+				["node", "runtime", "--approval-mode", "danger"],
+				async () => {
+					await expect(
+						resolveApprovalModeForRuntime({
+							workingDir: env.projectDir,
+							runtimeSandboxRoot: env.projectDir,
+						}),
+					).rejects.toThrow("Invalid --approval-mode");
+				},
+			);
+		} finally {
+			await env.cleanup();
+		}
+	});
+
+	test("reads project and default from projects.json", async () => {
+		const env = await withTempStorageEnv();
+		try {
+			const storagePaths = resolveStoragePaths();
+			await fs.mkdir(path.dirname(storagePaths.projectsFile), {
+				recursive: true,
+			});
+			const key = await resolveProjectPolicyKey(env.projectDir, env.projectDir);
+			await fs.writeFile(
+				storagePaths.projectsFile,
+				`${JSON.stringify(
+					{
+						version: 1,
+						default: { approval_mode: "trusted" },
+						projects: {
+							[key]: { approval_mode: "full-access" },
+						},
+					},
+					null,
+					2,
+				)}\n`,
+				"utf8",
+			);
+			const result = await resolveApprovalModeForRuntime({
+				workingDir: env.projectDir,
+				runtimeSandboxRoot: env.projectDir,
+			});
+			expect(result.approvalMode).toBe("full-access");
+			expect(result.source).toBe("project");
+
+			await fs.writeFile(
+				storagePaths.projectsFile,
+				`${JSON.stringify(
+					{
+						version: 1,
+						default: { approval_mode: "trusted" },
+						projects: {},
+					},
+					null,
+					2,
+				)}\n`,
+				"utf8",
+			);
+			const fallbackToDefault = await resolveApprovalModeForRuntime({
+				workingDir: env.projectDir,
+				runtimeSandboxRoot: env.projectDir,
+			});
+			expect(fallbackToDefault.approvalMode).toBe("trusted");
+			expect(fallbackToDefault.source).toBe("default");
+		} finally {
+			await env.cleanup();
+		}
+	});
+
+	test("project key uses sandbox root so subdirectories resolve to same project entry", async () => {
+		const env = await withTempStorageEnv();
+		try {
+			const storagePaths = resolveStoragePaths();
+			await fs.mkdir(path.dirname(storagePaths.projectsFile), {
+				recursive: true,
+			});
+			const sandboxRoot = env.projectDir;
+			const nestedWorkingDir = path.join(env.projectDir, "packages", "runtime");
+			await fs.mkdir(nestedWorkingDir, { recursive: true });
+			const key = await resolveProjectPolicyKey(nestedWorkingDir, sandboxRoot);
+			await fs.writeFile(
+				storagePaths.projectsFile,
+				`${JSON.stringify(
+					{
+						version: 1,
+						projects: {
+							[key]: { approval_mode: "trusted" },
+						},
+					},
+					null,
+					2,
+				)}\n`,
+				"utf8",
+			);
+			const result = await resolveApprovalModeForRuntime({
+				workingDir: nestedWorkingDir,
+				runtimeSandboxRoot: sandboxRoot,
+			});
+			expect(result.approvalMode).toBe("trusted");
+			expect(result.source).toBe("project");
+		} finally {
+			await env.cleanup();
+		}
+	});
+
+	test("throws explicit error when projects.json is invalid", async () => {
+		const env = await withTempStorageEnv();
+		try {
+			const storagePaths = resolveStoragePaths();
+			await fs.mkdir(path.dirname(storagePaths.projectsFile), {
+				recursive: true,
+			});
+			await fs.writeFile(storagePaths.projectsFile, "{\"version\":1", "utf8");
+			await expect(
+				resolveApprovalModeForRuntime({
+					workingDir: env.projectDir,
+					runtimeSandboxRoot: env.projectDir,
+				}),
+			).rejects.toThrow("Failed to load approval mode policy");
+		} finally {
+			await env.cleanup();
+		}
+	});
+});

--- a/packages/runtime/tests/config.test.ts
+++ b/packages/runtime/tests/config.test.ts
@@ -13,6 +13,7 @@ import {
 	updateModel,
 	updateTuiTheme,
 } from "../src/config";
+import { resolveApprovalModeForRuntime } from "../src/permissions/approval-mode";
 
 describe("runtime config resolvers", () => {
 	test("resolveReasoningEffort accepts supported values", () => {
@@ -479,6 +480,124 @@ describe("runtime config resolvers", () => {
 				},
 			});
 		} finally {
+			for (const [key, value] of restore.reverse()) {
+				if (value === undefined) {
+					delete process.env[key];
+				} else {
+					process.env[key] = value;
+				}
+			}
+			await fs.rm(tempRoot, { recursive: true, force: true });
+		}
+	});
+
+	test("resolveApprovalModeForRuntime uses precedence cli > env > project > default > fallback", async () => {
+		const previous = process.env.CODELIA_APPROVAL_MODE;
+		delete process.env.CODELIA_APPROVAL_MODE;
+		const tempRoot = await fs.mkdtemp(
+			path.join(os.tmpdir(), "codelia-approval-runtime-"),
+		);
+		const restore: Array<[string, string | undefined]> = [];
+		const setEnv = (key: string, value: string) => {
+			restore.push([key, process.env[key]]);
+			process.env[key] = value;
+		};
+		setEnv("CODELIA_LAYOUT", "xdg");
+		setEnv("XDG_STATE_HOME", path.join(tempRoot, "state"));
+		setEnv("XDG_CACHE_HOME", path.join(tempRoot, "cache"));
+		setEnv("XDG_CONFIG_HOME", path.join(tempRoot, "config"));
+		setEnv("XDG_DATA_HOME", path.join(tempRoot, "data"));
+		const projectDir = path.join(tempRoot, "workspace", "repo");
+		const nestedDir = path.join(projectDir, "packages", "runtime");
+		await fs.mkdir(nestedDir, { recursive: true });
+		const projectsPath = path.join(
+			process.env.XDG_CONFIG_HOME ?? "",
+			"codelia",
+			"projects.json",
+		);
+		await fs.mkdir(path.dirname(projectsPath), { recursive: true });
+
+		try {
+			const noConfig = await resolveApprovalModeForRuntime({
+				workingDir: nestedDir,
+				runtimeSandboxRoot: projectDir,
+			});
+			expect(noConfig.approvalMode).toBe("minimal");
+			expect(noConfig.source).toBe("fallback");
+
+			await fs.writeFile(
+				projectsPath,
+				`${JSON.stringify(
+					{
+						version: 1,
+						default: { approval_mode: "trusted" },
+						projects: {
+							[projectDir]: { approval_mode: "full-access" },
+						},
+					},
+					null,
+					2,
+				)}\n`,
+				"utf8",
+			);
+			const fromProject = await resolveApprovalModeForRuntime({
+				workingDir: nestedDir,
+				runtimeSandboxRoot: projectDir,
+			});
+			expect(fromProject.approvalMode).toBe("full-access");
+			expect(fromProject.source).toBe("project");
+
+			await fs.writeFile(
+				projectsPath,
+				`${JSON.stringify(
+					{
+						version: 1,
+						default: { approval_mode: "trusted" },
+						projects: {},
+					},
+					null,
+					2,
+				)}\n`,
+				"utf8",
+			);
+			const fromDefault = await resolveApprovalModeForRuntime({
+				workingDir: nestedDir,
+				runtimeSandboxRoot: projectDir,
+			});
+			expect(fromDefault.approvalMode).toBe("trusted");
+			expect(fromDefault.source).toBe("default");
+
+			process.env.CODELIA_APPROVAL_MODE = "minimal";
+			const fromEnv = await resolveApprovalModeForRuntime({
+				workingDir: nestedDir,
+				runtimeSandboxRoot: projectDir,
+			});
+			expect(fromEnv.approvalMode).toBe("minimal");
+			expect(fromEnv.source).toBe("env");
+
+			const originalArgv = [...process.argv];
+			try {
+				process.argv = [
+					"node",
+					"runtime",
+					"--approval-mode",
+					"full-access",
+				];
+				const fromCli = await resolveApprovalModeForRuntime({
+					workingDir: nestedDir,
+					runtimeSandboxRoot: projectDir,
+				});
+				expect(fromCli.approvalMode).toBe("full-access");
+				expect(fromCli.source).toBe("cli");
+			} finally {
+				process.argv = originalArgv;
+			}
+		} finally {
+			if (previous === undefined) {
+				delete process.env.CODELIA_APPROVAL_MODE;
+			} else {
+				process.env.CODELIA_APPROVAL_MODE = previous;
+			}
 			for (const [key, value] of restore.reverse()) {
 				if (value === undefined) {
 					delete process.env[key];

--- a/packages/runtime/tests/permissions.test.ts
+++ b/packages/runtime/tests/permissions.test.ts
@@ -23,8 +23,9 @@ describe("PermissionService", () => {
 
 	test("system allowlist includes read-only git commands", () => {
 		const service = new PermissionService({
-			system: buildSystemPermissions(),
+			system: buildSystemPermissions("minimal"),
 			user: { allow: [] },
+			approvalMode: "minimal",
 		});
 
 		expect(
@@ -57,10 +58,11 @@ describe("PermissionService", () => {
 
 	test("skill_load deny rule can block a specific skill name", () => {
 		const service = new PermissionService({
-			system: buildSystemPermissions(),
+			system: buildSystemPermissions("minimal"),
 			user: {
 				deny: [{ tool: "skill_load", skill_name: "dangerous-skill" }],
 			},
+			approvalMode: "minimal",
 		});
 
 		expect(
@@ -100,12 +102,13 @@ describe("PermissionService", () => {
 
 	test("allows cd only when target stays in sandbox", () => {
 		const service = new PermissionService({
-			system: buildSystemPermissions(),
+			system: buildSystemPermissions("minimal"),
 			user: { allow: [] },
 			bashPathGuard: {
 				rootDir: "/repo",
 				workingDir: "/repo",
 			},
+			approvalMode: "minimal",
 		});
 
 		expect(service.evaluate("bash", bashArgs("cd packages")).decision).toBe(
@@ -395,5 +398,54 @@ describe("PermissionService", () => {
 
 		const result = service.evaluate("bash", bashArgs("echo 'a | b'"));
 		expect(result.decision).toBe("allow");
+	});
+
+	test("trusted mode allows workspace write tools and trusted bash allowlist", () => {
+		const service = new PermissionService({
+			system: buildSystemPermissions("trusted"),
+			user: { allow: [] },
+			approvalMode: "trusted",
+		});
+		expect(service.evaluate("write", JSON.stringify({})).decision).toBe("allow");
+		expect(service.evaluate("edit", JSON.stringify({})).decision).toBe("allow");
+		expect(service.evaluate("bash", bashArgs("sed -n '1,5p' README.md")).decision).toBe(
+			"allow",
+		);
+		expect(service.evaluate("bash", bashArgs("awk '{print $1}' README.md")).decision).toBe(
+			"allow",
+		);
+		expect(service.evaluate("lane_create", JSON.stringify({})).decision).toBe(
+			"confirm",
+		);
+	});
+
+	test("minimal mode still requires confirm for trusted-only bash commands", () => {
+		const service = new PermissionService({
+			system: buildSystemPermissions("minimal"),
+			user: { allow: [] },
+			approvalMode: "minimal",
+		});
+		expect(service.evaluate("bash", bashArgs("sed -n '1,5p' README.md")).decision).toBe(
+			"confirm",
+		);
+		expect(service.evaluate("bash", bashArgs("awk '{print $1}' README.md")).decision).toBe(
+			"confirm",
+		);
+	});
+
+	test("full-access mode allows non-denied calls without confirm", () => {
+		const service = new PermissionService({
+			approvalMode: "full-access",
+			user: {
+				deny: [{ tool: "bash", command: "rm" }],
+			},
+		});
+		expect(service.evaluate("write", JSON.stringify({})).decision).toBe("allow");
+		expect(service.evaluate("bash", bashArgs("git push origin main")).decision).toBe(
+			"allow",
+		);
+		expect(service.evaluate("bash", bashArgs("rm -rf /tmp/demo")).decision).toBe(
+			"deny",
+		);
 	});
 });

--- a/packages/shared-types/src/approval.ts
+++ b/packages/shared-types/src/approval.ts
@@ -1,0 +1,12 @@
+export type ApprovalMode = "minimal" | "trusted" | "full-access";
+
+export const parseApprovalMode = (value: unknown): ApprovalMode | undefined => {
+	if (
+		value === "minimal" ||
+		value === "trusted" ||
+		value === "full-access"
+	) {
+		return value;
+	}
+	return undefined;
+};

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./approval";
 export * from "./events";
 export * from "./session";
 export * from "./skills";

--- a/packages/storage/AGENTS.md
+++ b/packages/storage/AGENTS.md
@@ -4,7 +4,8 @@
 
 - Resolves Codelia storage paths with a default home layout under `~/.codelia`.
 - XDG layout is opt-in via `CODELIA_LAYOUT=xdg` and splits config/cache/state paths.
-- Config path set includes `config.json` / `auth.json` / `mcp-auth.json`.
+- Config path set includes `config.json` / `auth.json` / `mcp-auth.json` / `projects.json`.
+- `ProjectsPolicyStore` provides read/write and strict schema validation for global `projects.json` (approval mode policy), using atomic write + `0600` permission (non-Windows chmod errors are surfaced).
 - `McpAuthStore` provides read/write and normalization (permission `0600`) for `mcp-auth.json` and is commonly used by runtime/cli.
 - `StoragePathServiceImpl` implements the core `StoragePathService` DI interface.
 - Session logs live under `sessions/YYYY/MM/DD/` and are written by `SessionStoreWriterImpl`.

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -24,6 +24,7 @@
 	},
 	"dependencies": {
 		"@codelia/core": "0.1.20",
+		"@codelia/shared-types": "0.1.20",
 		"better-sqlite3": "^12.6.2"
 	},
 	"publishConfig": {

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -9,6 +9,7 @@ export {
 	McpAuthStore,
 	type McpOAuthTokens,
 } from "./mcp-auth-store";
+export { type ProjectsPolicyFile, ProjectsPolicyStore } from "./projects-store";
 export { ensureStorageDirs, resolveStoragePaths } from "./paths";
 export { RunEventStoreFactoryImpl } from "./run-event-store";
 export { StoragePathServiceImpl } from "./service";

--- a/packages/storage/src/paths.ts
+++ b/packages/storage/src/paths.ts
@@ -13,6 +13,7 @@ const XDG_DIR_NAME = "codelia";
 const CONFIG_FILENAME = "config.json";
 const AUTH_FILENAME = "auth.json";
 const MCP_AUTH_FILENAME = "mcp-auth.json";
+const PROJECTS_FILENAME = "projects.json";
 const CACHE_DIRNAME = "cache";
 const TOOL_OUTPUT_CACHE_DIRNAME = "tool-output";
 const SESSIONS_DIRNAME = "sessions";
@@ -59,6 +60,7 @@ function buildHomeLayout(root: string): StoragePaths {
 		configFile: path.join(configDir, CONFIG_FILENAME),
 		authFile: path.join(configDir, AUTH_FILENAME),
 		mcpAuthFile: path.join(configDir, MCP_AUTH_FILENAME),
+		projectsFile: path.join(configDir, PROJECTS_FILENAME),
 		cacheDir: path.join(root, CACHE_DIRNAME),
 		toolOutputCacheDir: path.join(
 			root,
@@ -85,6 +87,7 @@ function buildXdgLayout(): StoragePaths {
 		configFile: path.join(configDir, CONFIG_FILENAME),
 		authFile: path.join(configDir, AUTH_FILENAME),
 		mcpAuthFile: path.join(configDir, MCP_AUTH_FILENAME),
+		projectsFile: path.join(configDir, PROJECTS_FILENAME),
 		cacheDir,
 		toolOutputCacheDir: path.join(cacheDir, TOOL_OUTPUT_CACHE_DIRNAME),
 		sessionsDir: path.join(stateDir, SESSIONS_DIRNAME),

--- a/packages/storage/src/projects-store.ts
+++ b/packages/storage/src/projects-store.ts
@@ -1,0 +1,134 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import type { StoragePaths } from "@codelia/core";
+import {
+	parseApprovalMode,
+	type ApprovalMode,
+} from "@codelia/shared-types";
+import { ensureStorageDirs, resolveStoragePaths } from "./paths";
+
+export type ProjectsPolicyFile = {
+	version: 1;
+	default?: {
+		approval_mode?: ApprovalMode;
+	};
+	projects?: Record<
+		string,
+		{
+			approval_mode?: ApprovalMode;
+		}
+	>;
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+	typeof value === "object" && value !== null && !Array.isArray(value);
+
+const parseApprovalModeField = (
+	fieldPath: string,
+	value: unknown,
+): ApprovalMode => {
+	const parsed = parseApprovalMode(value);
+	if (!parsed) {
+		throw new Error(`${fieldPath} is invalid`);
+	}
+	return parsed;
+};
+
+const normalizeProjectsPolicyFile = (value: unknown): ProjectsPolicyFile => {
+	if (!isRecord(value)) {
+		throw new Error("projects policy must be an object");
+	}
+	if (value.version !== 1) {
+		throw new Error("projects policy version must be 1");
+	}
+
+	const normalized: ProjectsPolicyFile = { version: 1 };
+	const defaultValue = value.default;
+	if (defaultValue !== undefined) {
+		if (!isRecord(defaultValue)) {
+			throw new Error("projects policy default must be an object");
+		}
+		if (defaultValue.approval_mode !== undefined) {
+			normalized.default = {
+				approval_mode: parseApprovalModeField(
+					"projects policy default.approval_mode",
+					defaultValue.approval_mode,
+				),
+			};
+		}
+	}
+
+	const projectsValue = value.projects;
+	if (projectsValue !== undefined) {
+		if (!isRecord(projectsValue)) {
+			throw new Error("projects policy projects must be an object");
+		}
+		const entries: Record<string, { approval_mode?: ApprovalMode }> = {};
+		for (const [key, projectValue] of Object.entries(projectsValue)) {
+			if (!isRecord(projectValue)) {
+				throw new Error(`projects policy projects['${key}'] must be an object`);
+			}
+			if (projectValue.approval_mode !== undefined) {
+				entries[key] = {
+					approval_mode: parseApprovalModeField(
+						`projects policy projects['${key}'].approval_mode`,
+						projectValue.approval_mode,
+					),
+				};
+			}
+		}
+		if (Object.keys(entries).length > 0) {
+			normalized.projects = entries;
+		}
+	}
+	return normalized;
+};
+
+const atomicWriteFile = async (filePath: string, content: string): Promise<void> => {
+	const dirPath = path.dirname(filePath);
+	const fileName = path.basename(filePath);
+	const tempPath = path.join(
+		dirPath,
+		`.${fileName}.${process.pid}.${Date.now()}.tmp`,
+	);
+	await fs.writeFile(tempPath, content, { mode: 0o600 });
+	await fs.rename(tempPath, filePath);
+	if (process.platform !== "win32") {
+		await fs.chmod(filePath, 0o600);
+	}
+};
+
+export class ProjectsPolicyStore {
+	private readonly paths: StoragePaths;
+
+	constructor(paths?: StoragePaths) {
+		this.paths = paths ?? resolveStoragePaths();
+	}
+
+	getFilePath(): string {
+		return this.paths.projectsFile;
+	}
+
+	async load(): Promise<ProjectsPolicyFile | null> {
+		try {
+			const raw = await fs.readFile(this.paths.projectsFile, "utf8");
+			const parsed = JSON.parse(raw) as unknown;
+			return normalizeProjectsPolicyFile(parsed);
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+				return null;
+			}
+			throw error;
+		}
+	}
+
+	async save(data: ProjectsPolicyFile): Promise<void> {
+		if (data.version !== 1) {
+			throw new Error("projects policy version must be 1");
+		}
+		await ensureStorageDirs(this.paths);
+		const content = `${JSON.stringify(data, null, 2)}\n`;
+		await atomicWriteFile(this.paths.projectsFile, content);
+	}
+}
+

--- a/packages/storage/tests/projects-store.test.ts
+++ b/packages/storage/tests/projects-store.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "bun:test";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { ProjectsPolicyStore, resolveStoragePaths } from "../src";
+
+describe("ProjectsPolicyStore", () => {
+	test("resolveStoragePaths includes projects file", async () => {
+		const root = await fs.mkdtemp(path.join(os.tmpdir(), "codelia-storage-"));
+		try {
+			const paths = resolveStoragePaths({ rootOverride: root });
+			expect(paths.projectsFile).toBe(path.join(root, "projects.json"));
+		} finally {
+			await fs.rm(root, { recursive: true, force: true });
+		}
+	});
+
+	test("save/load roundtrip keeps valid approval policy entries", async () => {
+		const root = await fs.mkdtemp(path.join(os.tmpdir(), "codelia-projects-"));
+		try {
+			const paths = resolveStoragePaths({ rootOverride: root });
+			const store = new ProjectsPolicyStore(paths);
+			await store.save({
+				version: 1,
+				default: { approval_mode: "minimal" },
+				projects: {
+					"/repo/a": { approval_mode: "trusted" },
+				},
+			});
+			const loaded = await store.load();
+			expect(loaded).toEqual({
+				version: 1,
+				default: { approval_mode: "minimal" },
+				projects: {
+					"/repo/a": { approval_mode: "trusted" },
+				},
+			});
+		} finally {
+			await fs.rm(root, { recursive: true, force: true });
+		}
+	});
+
+	test("load throws for invalid approval mode entries", async () => {
+		const root = await fs.mkdtemp(path.join(os.tmpdir(), "codelia-projects-"));
+		try {
+			const paths = resolveStoragePaths({ rootOverride: root });
+			await fs.mkdir(path.dirname(paths.projectsFile), { recursive: true });
+			await fs.writeFile(
+				paths.projectsFile,
+				JSON.stringify(
+					{
+						version: 1,
+						default: { approval_mode: "not-valid" },
+						projects: {
+							"/repo/a": { approval_mode: "trusted" },
+						},
+					},
+					null,
+					2,
+				),
+				"utf8",
+			);
+			const store = new ProjectsPolicyStore(paths);
+			await expect(store.load()).rejects.toThrow(
+				"projects policy default.approval_mode is invalid",
+			);
+		} finally {
+			await fs.rm(root, { recursive: true, force: true });
+		}
+	});
+
+	test("load throws for invalid JSON", async () => {
+		const root = await fs.mkdtemp(path.join(os.tmpdir(), "codelia-projects-"));
+		try {
+			const paths = resolveStoragePaths({ rootOverride: root });
+			await fs.mkdir(path.dirname(paths.projectsFile), { recursive: true });
+			await fs.writeFile(paths.projectsFile, "{\"version\":1", "utf8");
+			const store = new ProjectsPolicyStore(paths);
+			await expect(store.load()).rejects.toThrow();
+		} finally {
+			await fs.rm(root, { recursive: true, force: true });
+		}
+	});
+});

--- a/packages/storage/tests/session-state.test.ts
+++ b/packages/storage/tests/session-state.test.ts
@@ -237,6 +237,7 @@ describe("@codelia/storage SessionStateStoreImpl", () => {
 			const paths = resolveStoragePaths({ rootOverride: root });
 			expect(paths.root).toBe(root);
 			expect(paths.configFile).toBe(path.join(root, "config.json"));
+			expect(paths.projectsFile).toBe(path.join(root, "projects.json"));
 			expect(paths.sessionsDir).toBe(path.join(root, "sessions"));
 			expect(paths.toolOutputCacheDir).toBe(
 				path.join(root, "cache", "tool-output"),


### PR DESCRIPTION
## Summary

Implements lane1 core work for approval mode runtime policy and global projects policy storage, plus follow-up design adjustments:

- Runtime approval mode precedence
  - `--approval-mode` (CLI argv) > `CODELIA_APPROVAL_MODE` > `projects.json` project entry > `projects.json` default > fallback `minimal`
- Global per-project policy store
  - Adds strict `projects.json` read/write store with schema validation
  - Atomic writes and 0600 permission handling
- Permission integration for `minimal|trusted|full-access`
  - `trusted` extends system allowlist (`write`/`edit`, bash `sed`/`awk`)
  - `full-access` skips confirm but still enforces deny rules

Also includes refactors for readability/maintainability:

- Move `ApprovalMode` type/parser to `@codelia/shared-types`
- Route approval-mode propagation by runtime argv through TUI spawn args (no new propagation env var)
- Extract full-access evaluation helpers in `PermissionService`
- Split approval-mode resolver internals into focused helper functions

## Explicit failure behavior (no silent ignore)

- Invalid/missing CLI `--approval-mode` value now errors explicitly
- Invalid `CODELIA_APPROVAL_MODE` now errors explicitly
- Malformed/invalid `projects.json` load errors are surfaced explicitly with file path context
- Non-Windows chmod failures for `projects.json` writes are surfaced as errors

## Tests

Validated with:

- `bun run test` (includes `bun test packages/*/tests` + `bun run test:tui`)
- `bun run typecheck`
- Focused suites during development:
  - `packages/runtime/tests/approval-mode.test.ts`
  - `packages/runtime/tests/config.test.ts`
  - `packages/runtime/tests/permissions.test.ts`
  - `packages/storage/tests/projects-store.test.ts`
  - `packages/cli/tests/runtime-launcher.test.ts`
  - `packages/cli/tests/basic-options.test.ts`

All pass locally.
