### PR TITLE
tui: remove queued auto-dispatch status log

### DIFF
--- a/crates/tui/src/app/handlers/command.rs
+++ b/crates/tui/src/app/handlers/command.rs
@@ -913,7 +913,6 @@ pub(crate) fn try_dispatch_queued_prompt(
     let Some(next_prompt) = app.pending_prompt_queue.pop_front() else {
         return false;
     };
-    let queue_id = next_prompt.queue_id.clone();
     app.dispatching_prompt = Some(next_prompt);
 
     let sent = if let Some(dispatching) = app.dispatching_prompt.clone() {
@@ -924,14 +923,6 @@ pub(crate) fn try_dispatch_queued_prompt(
 
     if sent {
         app.next_queue_dispatch_retry_at = None;
-        app.push_line(
-            LogKind::Status,
-            format!(
-                "Dispatching queued prompt {} (queue={})",
-                queue_id,
-                app.pending_prompt_queue.len()
-            ),
-        );
         return true;
     }
 


### PR DESCRIPTION
## Summary
- remove the noisy status line emitted on queued prompt auto-dispatch success
- keep queued prompt dispatch/retry behavior unchanged

## Changes
- `crates/tui/src/app/handlers/command.rs`
  - in `try_dispatch_queued_prompt`, remove success-path `app.push_line(...)` for:
    - `Dispatching queued prompt qN (queue=M)`
  - remove now-unused `queue_id` local

## Verification
- `cargo test --manifest-path crates/tui/Cargo.toml queued_dispatch`

## Impact
- user-visible: less status-line noise during queued auto-dispatch
- no protocol/runtime behavior changes
