### PR TITLE
[codex] Add GPT-5.5 static model entries

### DIFF
--- a/packages/core/src/models/AGENTS.md
+++ b/packages/core/src/models/AGENTS.md
@@ -7,3 +7,9 @@ Location for model definitions and registries. Solve and list using `registry.ts
 Visit each provider's site to define supported models.
 
 The model list is a snapshot, so check the update date and review it regularly.
+
+## OpenAI GPT-5.5
+
+- `gpt-5.5` is available in the static OpenAI registry, but it is not the default model unless `OPENAI_DEFAULT_MODEL` is intentionally changed.
+- OpenAI's April 2026 GPT-5.5 release note describes API context as 1M and Codex app context as 400K; models.dev currently carries the precise API limits as `context: 1_050_000`, `input: 920_000`, and `output: 130_000`.
+- Follow the `gpt-5.4` pattern: keep plain `gpt-5.5` capped for normal use (`maxInputTokens: 270_000`) and expose full API context through synthetic `gpt-5.5-1M` / `gpt-5.5-full` aliases that send provider model `gpt-5.5`.

--- a/packages/core/src/models/openai.ts
+++ b/packages/core/src/models/openai.ts
@@ -11,6 +11,26 @@ export const OPENAI_MODELS: ModelSpec[] = [
 		aliases: ["default"],
 	},
 	{
+		id: "gpt-5.5",
+		provider: "openai",
+		contextWindow: 1_050_000,
+		maxInputTokens: 270_000,
+		maxOutputTokens: 130_000,
+	},
+	{
+		id: "gpt-5.5-1M",
+		provider: "openai",
+		providerModelId: "gpt-5.5",
+		aliases: ["gpt-5.5-1m", "gpt-5.5-full"],
+		contextWindow: 1_050_000,
+		maxInputTokens: 920_000,
+		maxOutputTokens: 130_000,
+	},
+	{
+		id: "gpt-5.5-pro",
+		provider: "openai",
+	},
+	{
 		id: "gpt-5.4",
 		provider: "openai",
 		contextWindow: 1050000,

--- a/packages/runtime/tests/model-list-static.test.ts
+++ b/packages/runtime/tests/model-list-static.test.ts
@@ -5,6 +5,16 @@ import { buildProviderModelList } from "../src/rpc/model";
 describe("model.list static providers", () => {
 	test("details follow merged runtime registry for static providers", async () => {
 		const providerEntries: Record<string, ModelEntry> = {
+			"gpt-5.5": {
+				provider: "openai",
+				modelId: "gpt-5.5",
+				limits: {
+					contextWindow: 400_000,
+					inputTokens: 350_000,
+					outputTokens: 16_000,
+				},
+				releaseDate: "2026-04-23",
+			},
 			"gpt-5.4": {
 				provider: "openai",
 				modelId: "gpt-5.4",
@@ -39,6 +49,18 @@ describe("model.list static providers", () => {
 			providerEntriesOverride: providerEntries,
 		});
 
+		expect(result.details?.["gpt-5.5"]).toEqual({
+			release_date: "2026-04-23",
+			context_window: 1_050_000,
+			max_input_tokens: 270_000,
+			max_output_tokens: 130_000,
+		});
+		expect(result.details?.["gpt-5.5-1M"]).toEqual({
+			release_date: "2026-04-23",
+			context_window: 1_050_000,
+			max_input_tokens: 920_000,
+			max_output_tokens: 130_000,
+		});
 		expect(result.details?.["gpt-5.4"]).toEqual({
 			release_date: "2026-03-01",
 			context_window: 1_050_000,

--- a/packages/runtime/tests/model-registry.test.ts
+++ b/packages/runtime/tests/model-registry.test.ts
@@ -24,6 +24,31 @@ const buildMetadataService = (
 });
 
 describe("buildModelRegistry strict fallback", () => {
+	test("keeps static GPT-5.5 capped context when metadata is missing", async () => {
+		const registry = await buildModelRegistry(buildLlm("openai", "gpt-5.5"), {
+			strict: true,
+			metadataService: buildMetadataService({ openai: {} }),
+		});
+
+		const spec = resolveModel(registry, "gpt-5.5", "openai");
+		expect(spec?.contextWindow).toBe(1_050_000);
+		expect(spec?.maxInputTokens).toBe(270_000);
+		expect(spec?.maxOutputTokens).toBe(130_000);
+	});
+
+	test("resolves GPT-5.5 full-context alias to provider model", async () => {
+		const registry = await buildModelRegistry(buildLlm("openai", "gpt-5.5-1M"), {
+			strict: true,
+			metadataService: buildMetadataService({ openai: {} }),
+		});
+
+		const spec = resolveModel(registry, "gpt-5.5-full", "openai");
+		expect(spec?.providerModelId).toBe("gpt-5.5");
+		expect(spec?.contextWindow).toBe(1_050_000);
+		expect(spec?.maxInputTokens).toBe(920_000);
+		expect(spec?.maxOutputTokens).toBe(130_000);
+	});
+
 	test("does not throw when metadata is missing but model exists in default registry", async () => {
 		const registry = await buildModelRegistry(
 			buildLlm("openai", "openai/gpt-5.4"),


### PR DESCRIPTION
## Summary
- add OpenAI gpt-5.5 static model entries without changing the default model
- mirror the gpt-5.4 capped/full-context pattern with gpt-5.5 and gpt-5.5-1M
- add runtime registry and model list coverage for static GPT-5.5 limits

## Validation
- bun test packages/core/tests/model-registry.test.ts packages/runtime/tests/model-registry.test.ts packages/runtime/tests/model-list-static.test.ts packages/core/tests/openai-chat.test.ts
- bun run typecheck