### PR TITLE
[codex] add session-scoped model switching

### DIFF
--- a/crates/tui/AGENTS.md
+++ b/crates/tui/AGENTS.md
@@ -61,7 +61,7 @@ The TUI launches runtime, sends UI protocol requests, and renders runtime events
 - `shell.wait` may return `still_running: true` after its bounded wait window expires; TUI should surface that as status and leave the task running rather than enqueueing a deferred shell result.
 - While an attached shell wait is active and the runtime advertises `supports_shell_detach`, `Ctrl+B` issues `shell.detach { task_id }` and leaves the shell task running in background.
 - `/tasks` now uses the public `task.*` RPC surface for list/show/cancel over retained task metadata.
-- `/model` persists the selected model with `model.set scope=config`; `/model --session` and `/model-session` use `scope=session` for the active runtime/session only, and `/model-session reset` clears the override. Status renders session-scoped models as `model~:`.
+- `/model` persists the selected model with `model.set scope=config`; `/model --session` and `/model-session` use `scope=session` for the active session (`SessionState.meta.codelia_model_override`), and `/model-session reset` clears the override. Status renders session-scoped models as `model~:`.
 - `/fast [on|off|toggle]` updates the current model via `model.set` with the `fast` flag; the runtime gates actual provider fast mode by model support. Status renders enabled fast mode with `⚡`.
 - `/tasks` list/show/cancel surfaces a shell task's public `key` first (for example `build-xxxxxxxx`), while still showing the underlying `task_id` because the current command surface still accepts `task_id` arguments.
 - Agent shell tool rendering keeps `shell_list` user-facing output compact: `ShellList: ...` summary plus one muted line per task (`state | key | optional label | command`) instead of dumping the raw JSON payload.

--- a/crates/tui/AGENTS.md
+++ b/crates/tui/AGENTS.md
@@ -61,7 +61,8 @@ The TUI launches runtime, sends UI protocol requests, and renders runtime events
 - `shell.wait` may return `still_running: true` after its bounded wait window expires; TUI should surface that as status and leave the task running rather than enqueueing a deferred shell result.
 - While an attached shell wait is active and the runtime advertises `supports_shell_detach`, `Ctrl+B` issues `shell.detach { task_id }` and leaves the shell task running in background.
 - `/tasks` now uses the public `task.*` RPC surface for list/show/cancel over retained task metadata.
-- `/fast [on|off|toggle]` updates the current model via `model.set` with the `fast` flag; the runtime gates actual provider fast mode by model support.
+- `/model` persists the selected model with `model.set scope=config`; `/model --session` and `/model-session` use `scope=session` for the active runtime/session only, and `/model-session reset` clears the override. Status renders session-scoped models as `model~:`.
+- `/fast [on|off|toggle]` updates the current model via `model.set` with the `fast` flag; the runtime gates actual provider fast mode by model support. Status renders enabled fast mode with `⚡`.
 - `/tasks` list/show/cancel surfaces a shell task's public `key` first (for example `build-xxxxxxxx`), while still showing the underlying `task_id` because the current command surface still accepts `task_id` arguments.
 - Agent shell tool rendering keeps `shell_list` user-facing output compact: `ShellList: ...` summary plus one muted line per task (`state | key | optional label | command`) instead of dumping the raw JSON payload.
 - Prompt submissions while a run is active are queued locally (FIFO) and auto-dispatched when run/pending/dialog gates are clear.

--- a/crates/tui/src/app/app_state/mod.rs
+++ b/crates/tui/src/app/app_state/mod.rs
@@ -2,10 +2,10 @@ use crate::app::state::InputState;
 use crate::app::state::LogLine;
 use crate::app::state::{
     ConfirmDialogState, ContextPanelState, LaneListPanelState, ModelListMode, ModelListPanelState,
-    ModelPickerState, PendingImageAttachment, PerfDebugStats, PickDialogState, PromptDialogState,
-    ProviderPickerState, ReasoningPickerState, RenderState, SessionListPanelState,
-    SkillsListItemState, SkillsListPanelState, SkillsScopeFilter, StatusLineMode,
-    ThemeListPanelState, WrappedLogCache,
+    ModelPickerState, ModelSetScope, PendingImageAttachment, PerfDebugStats, PickDialogState,
+    PromptDialogState, ProviderPickerState, ReasoningPickerState, RenderState,
+    SessionListPanelState, SkillsListItemState, SkillsListPanelState, SkillsScopeFilter,
+    StatusLineMode, ThemeListPanelState, WrappedLogCache,
 };
 use serde_json::Value;
 use std::collections::{BTreeSet, HashMap, HashSet, VecDeque};
@@ -80,6 +80,7 @@ pub enum ErrorDetailMode {
 pub struct RpcPendingState {
     pub model_list_id: Option<String>,
     pub model_list_mode: Option<ModelListMode>,
+    pub model_list_scope: Option<ModelSetScope>,
     pub model_set_id: Option<String>,
     pub run_start_id: Option<String>,
     pub run_cancel_id: Option<String>,
@@ -112,9 +113,14 @@ pub struct RpcPendingState {
 pub enum PendingRpcMatch {
     SessionList,
     SessionHistory,
-    ModelList { mode: ModelListMode },
+    ModelList {
+        mode: ModelListMode,
+        scope: ModelSetScope,
+    },
     ModelSet,
-    McpList { detail_id: Option<String> },
+    McpList {
+        detail_id: Option<String>,
+    },
     LaneList,
     LaneStatus,
     LaneClose,
@@ -142,6 +148,7 @@ pub struct RuntimeInfoState {
     pub current_model: Option<String>,
     pub current_reasoning: Option<String>,
     pub current_fast: Option<bool>,
+    pub current_model_source: Option<String>,
     pub supports_mcp_list: bool,
     pub supports_skills_list: bool,
     pub supports_context_inspect: bool,
@@ -200,7 +207,11 @@ impl RpcPendingState {
         if self.model_list_id.as_deref() == Some(response_id) {
             self.model_list_id = None;
             let mode = self.model_list_mode.take().unwrap_or(ModelListMode::Picker);
-            return Some(PendingRpcMatch::ModelList { mode });
+            let scope = self
+                .model_list_scope
+                .take()
+                .unwrap_or(ModelSetScope::Config);
+            return Some(PendingRpcMatch::ModelList { mode, scope });
         }
 
         if self.model_set_id.as_deref() == Some(response_id) {

--- a/crates/tui/src/app/app_state/tests.rs
+++ b/crates/tui/src/app/app_state/tests.rs
@@ -1,6 +1,6 @@
 use super::{
-    AppState, ConfirmDialogState, ErrorDetailMode, ModelListMode, PendingRpcMatch, RpcPendingState,
-    SkillsListItemState, SkillsListPanelState, SkillsScopeFilter,
+    AppState, ConfirmDialogState, ErrorDetailMode, ModelListMode, ModelSetScope, PendingRpcMatch,
+    RpcPendingState, SkillsListItemState, SkillsListPanelState, SkillsScopeFilter,
 };
 use crate::app::state::LogKind;
 use crate::app::state::{ConfirmMode, ConfirmPhase, CursorPhase, SyncPhase};
@@ -217,9 +217,11 @@ fn rpc_pending_take_match_extracts_model_mode_and_clears_it() {
     assert_eq!(
         matched,
         Some(PendingRpcMatch::ModelList {
-            mode: ModelListMode::List
+            mode: ModelListMode::List,
+            scope: ModelSetScope::Config,
         })
     );
     assert!(pending.model_list_id.is_none());
     assert!(pending.model_list_mode.is_none());
+    assert!(pending.model_list_scope.is_none());
 }

--- a/crates/tui/src/app/handlers/command.rs
+++ b/crates/tui/src/app/handlers/command.rs
@@ -17,7 +17,8 @@ use queue::handle_queue_command;
 use slash::{
     handle_compact_command, handle_context_command, handle_errors_command, handle_fast_command,
     handle_help_command, handle_lane_command, handle_logout_command, handle_mcp_command,
-    handle_model_command, handle_skills_command, handle_tasks_command, handle_theme_command,
+    handle_model_command, handle_model_session_command, handle_skills_command,
+    handle_tasks_command, handle_theme_command,
 };
 
 const MODEL_PROVIDERS: &[&str] = &["openai", "anthropic", "openrouter"];
@@ -64,6 +65,8 @@ pub(crate) fn handle_enter(
         handle_compact_command(app, child_stdin, next_id, &trimmed, &mut parts);
     } else if command == "/model" {
         handle_model_command(app, child_stdin, next_id, &mut parts);
+    } else if command == "/model-session" {
+        handle_model_session_command(app, child_stdin, next_id, &mut parts);
     } else if command == "/fast" {
         handle_fast_command(app, child_stdin, next_id, &mut parts);
     } else if command == "/context" {

--- a/crates/tui/src/app/handlers/command/slash.rs
+++ b/crates/tui/src/app/handlers/command/slash.rs
@@ -7,7 +7,7 @@ use crate::app::state::{
     command_suggestion_rows, parse_theme_name, theme_options, LogKind, ThemeListPanelState,
 };
 use crate::app::{
-    AppState, ErrorDetailMode, ModelListMode, ProviderPickerState, SkillsScopeFilter,
+    AppState, ErrorDetailMode, ModelListMode, ModelSetScope, ProviderPickerState, SkillsScopeFilter,
 };
 use serde_json::json;
 
@@ -70,23 +70,107 @@ pub(super) fn handle_model_command<'a>(
     next_id: &mut impl FnMut() -> String,
     parts: &mut impl Iterator<Item = &'a str>,
 ) {
-    if let Some(model) = parts.next() {
-        app.model_list_panel = None;
-        app.reasoning_picker = None;
-        app.skills_list_panel = None;
-        app.theme_list_panel = None;
-        let id = next_id();
-        app.rpc_pending.model_set_id = Some(id.clone());
-        let (provider, name) = model
-            .split_once('/')
-            .map(|(provider, name)| (Some(provider), name))
-            .unwrap_or((app.runtime_info.current_provider.as_deref(), model));
-        if let Err(error) = send_model_set(child_stdin, &id, provider, name, None, None) {
-            app.push_error_report("send error", error.to_string());
+    let mut scope = ModelSetScope::Config;
+    let mut next = parts.next();
+    if matches!(next, Some("--session")) {
+        scope = ModelSetScope::Session;
+        next = parts.next();
+    }
+    if let Some(model) = next {
+        if parts.next().is_some() {
+            app.push_line(LogKind::Error, "usage: /model [--session] [provider/]name");
+            return;
         }
+        send_model_set_for_scope(app, child_stdin, next_id, model, scope);
         return;
     }
 
+    open_model_provider_picker(app, scope);
+}
+
+pub(super) fn handle_model_session_command<'a>(
+    app: &mut AppState,
+    child_stdin: &mut RuntimeStdin,
+    next_id: &mut impl FnMut() -> String,
+    parts: &mut impl Iterator<Item = &'a str>,
+) {
+    if let Some(model) = parts.next() {
+        if model == "reset" {
+            if parts.next().is_some() {
+                app.push_line(
+                    LogKind::Error,
+                    "usage: /model-session [provider/]name|reset",
+                );
+                return;
+            }
+            app.model_list_panel = None;
+            app.reasoning_picker = None;
+            app.skills_list_panel = None;
+            app.theme_list_panel = None;
+            let id = next_id();
+            app.rpc_pending.model_set_id = Some(id.clone());
+            if let Err(error) = send_model_set(
+                child_stdin,
+                &id,
+                None,
+                "",
+                None,
+                None,
+                Some(ModelSetScope::Session.as_str()),
+                true,
+            ) {
+                app.rpc_pending.model_set_id = None;
+                app.push_error_report("send error", error.to_string());
+            }
+            return;
+        }
+        if parts.next().is_some() {
+            app.push_line(
+                LogKind::Error,
+                "usage: /model-session [provider/]name|reset",
+            );
+            return;
+        }
+        send_model_set_for_scope(app, child_stdin, next_id, model, ModelSetScope::Session);
+        return;
+    }
+
+    open_model_provider_picker(app, ModelSetScope::Session);
+}
+
+fn send_model_set_for_scope(
+    app: &mut AppState,
+    child_stdin: &mut RuntimeStdin,
+    next_id: &mut impl FnMut() -> String,
+    model: &str,
+    scope: ModelSetScope,
+) {
+    app.model_list_panel = None;
+    app.reasoning_picker = None;
+    app.skills_list_panel = None;
+    app.theme_list_panel = None;
+    let id = next_id();
+    app.rpc_pending.model_set_id = Some(id.clone());
+    let (provider, name) = model
+        .split_once('/')
+        .map(|(provider, name)| (Some(provider), name))
+        .unwrap_or((app.runtime_info.current_provider.as_deref(), model));
+    if let Err(error) = send_model_set(
+        child_stdin,
+        &id,
+        provider,
+        name,
+        None,
+        None,
+        Some(scope.as_str()),
+        false,
+    ) {
+        app.rpc_pending.model_set_id = None;
+        app.push_error_report("send error", error.to_string());
+    }
+}
+
+fn open_model_provider_picker(app: &mut AppState, scope: ModelSetScope) {
     app.model_list_panel = None;
     app.reasoning_picker = None;
     app.skills_list_panel = None;
@@ -108,6 +192,7 @@ pub(super) fn handle_model_command<'a>(
             providers,
             selected,
             mode: ModelListMode::List,
+            scope,
         });
     }
 }
@@ -141,6 +226,11 @@ pub(super) fn handle_fast_command<'a>(
     app.theme_list_panel = None;
     let id = next_id();
     app.rpc_pending.model_set_id = Some(id.clone());
+    let scope = if app.runtime_info.current_model_source.as_deref() == Some("session") {
+        ModelSetScope::Session
+    } else {
+        ModelSetScope::Config
+    };
     if let Err(error) = send_model_set(
         child_stdin,
         &id,
@@ -148,6 +238,8 @@ pub(super) fn handle_fast_command<'a>(
         &model,
         None,
         Some(requested),
+        Some(scope.as_str()),
+        false,
     ) {
         app.rpc_pending.model_set_id = None;
         app.push_error_report("send error", error.to_string());

--- a/crates/tui/src/app/handlers/panels.rs
+++ b/crates/tui/src/app/handlers/panels.rs
@@ -4,7 +4,7 @@ use crate::app::runtime::{
 };
 use crate::app::state::parse_theme_name;
 use crate::app::state::LogKind;
-use crate::app::{AppState, ModelListMode, ModelListSubmitAction};
+use crate::app::{AppState, ModelListMode, ModelListSubmitAction, ModelSetScope};
 use crossterm::event::KeyCode;
 use std::io::BufWriter;
 use std::process::ChildStdin;
@@ -14,7 +14,12 @@ type RuntimeStdin = BufWriter<ChildStdin>;
 const REASONING_LEVELS: [&str; 4] = ["low", "medium", "high", "xhigh"];
 const SESSION_HISTORY_MAX_EVENTS: usize = 500;
 
-fn open_reasoning_picker(app: &mut AppState, provider: Option<&str>, model: String) {
+fn open_reasoning_picker(
+    app: &mut AppState,
+    provider: Option<&str>,
+    model: String,
+    scope: ModelSetScope,
+) {
     let levels = REASONING_LEVELS
         .iter()
         .map(|level| (*level).to_string())
@@ -28,6 +33,7 @@ fn open_reasoning_picker(app: &mut AppState, provider: Option<&str>, model: Stri
     app.reasoning_picker = Some(crate::app::ReasoningPickerState {
         provider: provider.map(str::to_string),
         model,
+        scope,
         levels,
         selected,
     });
@@ -288,7 +294,7 @@ pub(crate) fn handle_model_list_panel_key(
         KeyCode::Esc => {
             let pending_pick_id = match &panel.submit_action {
                 ModelListSubmitAction::UiPick { request_id, .. } => Some(request_id.clone()),
-                ModelListSubmitAction::ModelSet => None,
+                ModelListSubmitAction::ModelSet { .. } => None,
             };
             app.model_list_panel = None;
             if let Some(request_id) = pending_pick_id {
@@ -303,7 +309,9 @@ pub(crate) fn handle_model_list_panel_key(
             let selected = panel.selected;
             let model = panel.model_ids.get(selected).cloned();
             let submit_action = match &panel.submit_action {
-                ModelListSubmitAction::ModelSet => ModelListSubmitAction::ModelSet,
+                ModelListSubmitAction::ModelSet { scope } => {
+                    ModelListSubmitAction::ModelSet { scope: *scope }
+                }
                 ModelListSubmitAction::UiPick {
                     request_id,
                     item_ids,
@@ -315,9 +323,9 @@ pub(crate) fn handle_model_list_panel_key(
             app.model_list_panel = None;
             if let Some(model) = model {
                 match submit_action {
-                    ModelListSubmitAction::ModelSet => {
+                    ModelListSubmitAction::ModelSet { scope } => {
                         let provider = app.runtime_info.current_provider.clone();
-                        open_reasoning_picker(app, provider.as_deref(), model);
+                        open_reasoning_picker(app, provider.as_deref(), model, scope);
                     }
                     ModelListSubmitAction::UiPick {
                         request_id,
@@ -518,6 +526,7 @@ pub(crate) fn handle_provider_picker_key(
         KeyCode::Enter => {
             let provider = picker.providers.get(picker.selected).cloned();
             let mode = picker.mode;
+            let scope = picker.scope;
             app.provider_picker = None;
             app.model_list_panel = None;
             app.reasoning_picker = None;
@@ -525,6 +534,7 @@ pub(crate) fn handle_provider_picker_key(
                 let id = next_id();
                 app.rpc_pending.model_list_id = Some(id.clone());
                 app.rpc_pending.model_list_mode = Some(mode);
+                app.rpc_pending.model_list_scope = Some(scope);
                 let include_details = matches!(mode, ModelListMode::List);
                 if let Err(error) =
                     send_model_list(child_stdin, &id, Some(&provider), include_details)
@@ -567,7 +577,7 @@ pub(crate) fn handle_model_picker_key(
         KeyCode::Enter => {
             if let Some(model) = picker.models.get(picker.selected).cloned() {
                 let provider = app.runtime_info.current_provider.clone();
-                open_reasoning_picker(app, provider.as_deref(), model);
+                open_reasoning_picker(app, provider.as_deref(), model, ModelSetScope::Config);
             }
             app.model_picker = None;
             app.model_list_panel = None;
@@ -606,6 +616,7 @@ pub(crate) fn handle_reasoning_picker_key(
         KeyCode::Enter => {
             let provider = picker.provider.clone();
             let model = picker.model.clone();
+            let scope = picker.scope;
             let reasoning = picker.levels.get(picker.selected).cloned();
             app.reasoning_picker = None;
             if let Some(reasoning) = reasoning {
@@ -618,6 +629,8 @@ pub(crate) fn handle_reasoning_picker_key(
                     &model,
                     Some(&reasoning),
                     None,
+                    Some(scope.as_str()),
+                    false,
                 ) {
                     app.rpc_pending.model_set_id = None;
                     app.push_error_report("send error", error.to_string());

--- a/crates/tui/src/app/handlers/runtime_response/mod.rs
+++ b/crates/tui/src/app/handlers/runtime_response/mod.rs
@@ -166,8 +166,8 @@ fn handle_rpc_response(
             PendingRpcMatch::SessionHistory => {
                 session::handle_session_history_response(app, response)
             }
-            PendingRpcMatch::ModelList { mode } => {
-                model::handle_model_list_response(app, mode, response)
+            PendingRpcMatch::ModelList { mode, scope } => {
+                model::handle_model_list_response(app, mode, scope, response)
             }
             PendingRpcMatch::ModelSet => model::handle_model_set_response(app, response),
             PendingRpcMatch::McpList { detail_id } => {

--- a/crates/tui/src/app/handlers/runtime_response/model.rs
+++ b/crates/tui/src/app/handlers/runtime_response/model.rs
@@ -2,12 +2,13 @@ use super::formatters::push_rpc_error;
 use super::panel_builders::build_model_list_panel;
 use crate::app::runtime::RpcResponse;
 use crate::app::state::LogKind;
-use crate::app::{AppState, ModelListMode, ModelPickerState};
+use crate::app::{AppState, ModelListMode, ModelPickerState, ModelSetScope};
 use serde_json::Value;
 
 pub(super) fn handle_model_list_response(
     app: &mut AppState,
     mode: ModelListMode,
+    scope: ModelSetScope,
     response: RpcResponse,
 ) {
     if let Some(error) = response.error {
@@ -15,11 +16,16 @@ pub(super) fn handle_model_list_response(
         return;
     }
     if let Some(result) = response.result {
-        apply_model_list_result(app, mode, &result);
+        apply_model_list_result(app, mode, scope, &result);
     }
 }
 
-fn apply_model_list_result(app: &mut AppState, mode: ModelListMode, result: &Value) {
+fn apply_model_list_result(
+    app: &mut AppState,
+    mode: ModelListMode,
+    scope: ModelSetScope,
+    result: &Value,
+) {
     let provider = result
         .get("provider")
         .and_then(|value| value.as_str())
@@ -43,6 +49,10 @@ fn apply_model_list_result(app: &mut AppState, mode: ModelListMode, result: &Val
         .and_then(|value| value.as_str())
         .map(|value| value.to_string());
     let fast = result.get("fast").and_then(|value| value.as_bool());
+    let source = result
+        .get("source")
+        .and_then(|value| value.as_str())
+        .map(|value| value.to_string());
     if let Some(provider) = provider.clone() {
         app.runtime_info.current_provider = Some(provider);
     }
@@ -52,6 +62,9 @@ fn apply_model_list_result(app: &mut AppState, mode: ModelListMode, result: &Val
     }
     if let Some(fast) = fast {
         app.runtime_info.current_fast = Some(fast);
+    }
+    if let Some(source) = source {
+        app.runtime_info.current_model_source = Some(source);
     }
     app.skills_list_panel = None;
     app.theme_list_panel = None;
@@ -87,6 +100,7 @@ fn apply_model_list_result(app: &mut AppState, mode: ModelListMode, result: &Val
         models,
         details,
         current.as_deref(),
+        scope,
     ));
 }
 
@@ -109,6 +123,10 @@ pub(super) fn handle_model_set_response(app: &mut AppState, response: RpcRespons
             .and_then(|value| value.as_str())
             .unwrap_or("");
         let fast = result.get("fast").and_then(|value| value.as_bool());
+        let source = result
+            .get("source")
+            .and_then(|value| value.as_str())
+            .unwrap_or("config");
         if !name.is_empty() {
             app.runtime_info.current_model = Some(name.to_string());
             if !provider.is_empty() {
@@ -120,12 +138,16 @@ pub(super) fn handle_model_set_response(app: &mut AppState, response: RpcRespons
             if let Some(fast) = fast {
                 app.runtime_info.current_fast = Some(fast);
             }
+            app.runtime_info.current_model_source = Some(source.to_string());
             let mut suffix_parts = Vec::new();
             if !reasoning.is_empty() {
                 suffix_parts.push(reasoning.to_string());
             }
             if let Some(fast) = fast {
-                suffix_parts.push(if fast { "fast:on" } else { "fast:off" }.to_string());
+                suffix_parts.push(if fast { "fast" } else { "fast:off" }.to_string());
+            }
+            if source == "session" {
+                suffix_parts.push("session".to_string());
             }
             let suffix = if suffix_parts.is_empty() {
                 String::new()
@@ -134,7 +156,14 @@ pub(super) fn handle_model_set_response(app: &mut AppState, response: RpcRespons
             };
             app.push_line(
                 LogKind::Status,
-                format!("Model set: {provider}/{name}{suffix}"),
+                format!(
+                    "{}: {provider}/{name}{suffix}",
+                    if source == "session" {
+                        "Model set for this session"
+                    } else {
+                        "Model saved to config"
+                    }
+                ),
             );
             app.push_line(LogKind::Space, "");
         }

--- a/crates/tui/src/app/handlers/runtime_response/panel_builders.rs
+++ b/crates/tui/src/app/handlers/runtime_response/panel_builders.rs
@@ -1,7 +1,8 @@
 use super::formatters::truncate_text;
 use crate::app::runtime::UiPickRequest;
 use crate::app::{
-    ModelListPanelState, ModelListSubmitAction, ModelListViewMode, SessionListPanelState,
+    ModelListPanelState, ModelListSubmitAction, ModelListViewMode, ModelSetScope,
+    SessionListPanelState,
 };
 use serde_json::Value;
 
@@ -173,9 +174,9 @@ pub(super) fn build_session_list_panel(
         }
     } else {
         match workspace_label {
-            Some(workspace) => format!(
-                "Resume session — Current workspace: {workspace} (A: show all sessions)"
-            ),
+            Some(workspace) => {
+                format!("Resume session — Current workspace: {workspace} (A: show all sessions)")
+            }
             None => "Resume session — Current workspace only (A: show all sessions)".to_string(),
         }
     };
@@ -195,6 +196,7 @@ pub(super) fn build_model_list_panel(
     models: Vec<String>,
     details: Option<&serde_json::Map<String, Value>>,
     current: Option<&str>,
+    scope: ModelSetScope,
 ) -> ModelListPanelState {
     let format_usd = |value: Option<f64>| -> String {
         match value {
@@ -307,6 +309,6 @@ pub(super) fn build_model_list_panel(
         model_ids,
         selected,
         view_mode: ModelListViewMode::Limits,
-        submit_action: ModelListSubmitAction::ModelSet,
+        submit_action: ModelListSubmitAction::ModelSet { scope },
     }
 }

--- a/crates/tui/src/app/mod.rs
+++ b/crates/tui/src/app/mod.rs
@@ -13,10 +13,10 @@ mod app_state;
 pub(crate) use crate::app::state::{
     ConfirmDialogState, ConfirmMode, ConfirmPhase, ContextPanelState, CursorPhase, LaneListItem,
     LaneListPanelState, ModelListMode, ModelListPanelState, ModelListSubmitAction,
-    ModelListViewMode, ModelPickerState, PendingImageAttachment, PickDialogItem, PickDialogState,
-    PromptDialogState, ProviderPickerState, ReasoningPickerState, SessionListPanelState,
-    SkillsListItemState, SkillsListPanelState, SkillsScopeFilter, StatusLineMode, SyncPhase,
-    ThemeListPanelState, WrappedLogCache,
+    ModelListViewMode, ModelPickerState, ModelSetScope, PendingImageAttachment, PickDialogItem,
+    PickDialogState, PromptDialogState, ProviderPickerState, ReasoningPickerState,
+    SessionListPanelState, SkillsListItemState, SkillsListPanelState, SkillsScopeFilter,
+    StatusLineMode, SyncPhase, ThemeListPanelState, WrappedLogCache,
 };
 pub(crate) use app_state::{
     AppState, ErrorDetailMode, LogComponentSpan, PendingPromptRun, PendingRpcMatch,

--- a/crates/tui/src/app/runtime/client.rs
+++ b/crates/tui/src/app/runtime/client.rs
@@ -286,9 +286,13 @@ pub fn send_model_set(
     model: &str,
     reasoning: Option<&str>,
     fast: Option<bool>,
+    scope: Option<&str>,
+    reset: bool,
 ) -> std::io::Result<()> {
     let mut params = serde_json::Map::new();
-    params.insert("name".to_string(), json!(model));
+    if !reset {
+        params.insert("name".to_string(), json!(model));
+    }
     if let Some(provider) = provider {
         params.insert("provider".to_string(), json!(provider));
     }
@@ -297,6 +301,12 @@ pub fn send_model_set(
     }
     if let Some(fast) = fast {
         params.insert("fast".to_string(), json!(fast));
+    }
+    if let Some(scope) = scope {
+        params.insert("scope".to_string(), json!(scope));
+    }
+    if reset {
+        params.insert("reset".to_string(), json!(true));
     }
     let msg = json!({
         "jsonrpc": "2.0",

--- a/crates/tui/src/app/state/mod.rs
+++ b/crates/tui/src/app/state/mod.rs
@@ -13,8 +13,8 @@ pub(crate) use ui::{
     complete_slash_command, is_known_command, parse_theme_name, skill_suggestion_rows,
     theme_options, unknown_command_message, ConfirmDialogState, ConfirmMode, ContextPanelState,
     LaneListItem, LaneListPanelState, ModelListMode, ModelListPanelState, ModelListSubmitAction,
-    ModelListViewMode, ModelPickerState, PendingImageAttachment, PickDialogItem, PickDialogState,
-    PromptDialogState, ProviderPickerState, ReasoningPickerState, SessionListPanelState,
-    SkillsListItemState, SkillsListPanelState, SkillsScopeFilter, StatusLineMode,
-    ThemeListPanelState, ThemeName,
+    ModelListViewMode, ModelPickerState, ModelSetScope, PendingImageAttachment, PickDialogItem,
+    PickDialogState, PromptDialogState, ProviderPickerState, ReasoningPickerState,
+    SessionListPanelState, SkillsListItemState, SkillsListPanelState, SkillsScopeFilter,
+    StatusLineMode, ThemeListPanelState, ThemeName,
 };

--- a/crates/tui/src/app/state/ui/composer.rs
+++ b/crates/tui/src/app/state/ui/composer.rs
@@ -23,8 +23,13 @@ const SLASH_COMMANDS: &[SlashCommandSpec] = &[
     },
     SlashCommandSpec {
         command: "/model",
-        usage: "/model [provider/]name",
-        summary: "Set model or open model picker",
+        usage: "/model [--session] [provider/]name",
+        summary: "Save model or open model picker",
+    },
+    SlashCommandSpec {
+        command: "/model-session",
+        usage: "/model-session [provider/]name|reset",
+        summary: "Set model for this session",
     },
     SlashCommandSpec {
         command: "/fast",

--- a/crates/tui/src/app/state/ui/mod.rs
+++ b/crates/tui/src/app/state/ui/mod.rs
@@ -17,7 +17,7 @@ pub use dialogs::{
 };
 pub use model::{
     ModelListMode, ModelListPanelState, ModelListSubmitAction, ModelListViewMode, ModelPickerState,
-    ProviderPickerState, ReasoningPickerState,
+    ModelSetScope, ProviderPickerState, ReasoningPickerState,
 };
 pub use panels::{
     ContextPanelState, LaneListItem, LaneListPanelState, SessionListPanelState, ThemeListPanelState,

--- a/crates/tui/src/app/state/ui/model.rs
+++ b/crates/tui/src/app/state/ui/model.rs
@@ -6,6 +6,7 @@ pub struct ModelPickerState {
 pub struct ReasoningPickerState {
     pub provider: Option<String>,
     pub model: String,
+    pub scope: ModelSetScope,
     pub levels: Vec<String>,
     pub selected: usize,
 }
@@ -39,8 +40,25 @@ impl ModelListViewMode {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ModelSetScope {
+    Config,
+    Session,
+}
+
+impl ModelSetScope {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Config => "config",
+            Self::Session => "session",
+        }
+    }
+}
+
 pub enum ModelListSubmitAction {
-    ModelSet,
+    ModelSet {
+        scope: ModelSetScope,
+    },
     UiPick {
         request_id: String,
         item_ids: Vec<String>,
@@ -51,6 +69,7 @@ pub struct ProviderPickerState {
     pub providers: Vec<String>,
     pub selected: usize,
     pub mode: ModelListMode,
+    pub scope: ModelSetScope,
 }
 
 pub struct ModelListPanelState {

--- a/crates/tui/src/app/view/ui/status.rs
+++ b/crates/tui/src/app/view/ui/status.rs
@@ -34,12 +34,17 @@ pub(super) fn build_status_line(app: &AppState) -> Line<'static> {
             let provider = app.runtime_info.current_provider.as_deref().unwrap_or("-");
             let model = app.runtime_info.current_model.as_deref().unwrap_or("-");
             let reasoning = app.runtime_info.current_reasoning.as_deref().unwrap_or("-");
-            let fast = match app.runtime_info.current_fast {
-                Some(true) => "fast:on",
-                Some(false) => "fast:off",
-                None => "fast:-",
+            let label = if app.runtime_info.current_model_source.as_deref() == Some("session") {
+                "model~"
+            } else {
+                "model"
             };
-            segments.push(format!("model: {provider}/{model} [{reasoning}, {fast}]"));
+            let fast = if app.runtime_info.current_fast == Some(true) {
+                " ⚡"
+            } else {
+                ""
+            };
+            segments.push(format!("{label}: {provider}/{model} [{reasoning}{fast}]"));
             if let Some(percent) = app.context_left_percent {
                 segments.push(format!("context left: {percent}%"));
             }

--- a/dev-docs/config-write-policy.md
+++ b/dev-docs/config-write-policy.md
@@ -57,7 +57,8 @@ Examples:
 
 ## Current mappings (implemented)
 
-- `model.set`: `model.*` policy (default global + sticky override)
+- `model.set` with `scope=config`: `model.*` policy (default global + sticky override)
+- `model.set` with `scope=session`: no config write; updates the active runtime/session model override only
 - `permissions` confirm/apply flow: `permissions.*` policy (default project)
 - `theme.set`: `tui.*` policy (default global + sticky override)
 

--- a/dev-docs/config-write-policy.md
+++ b/dev-docs/config-write-policy.md
@@ -58,7 +58,7 @@ Examples:
 ## Current mappings (implemented)
 
 - `model.set` with `scope=config`: `model.*` policy (default global + sticky override)
-- `model.set` with `scope=session`: no config write; updates the active runtime/session model override only
+- `model.set` with `scope=session`: no config write; stores the active session override in `SessionState.meta.codelia_model_override`
 - `permissions` confirm/apply flow: `permissions.*` policy (default project)
 - `theme.set`: `tui.*` policy (default global + sticky override)
 

--- a/dev-docs/specs/tui-operation-reference.md
+++ b/dev-docs/specs/tui-operation-reference.md
@@ -16,7 +16,8 @@ Slash commands available in composer:
 
 - `/help`: print command list to log
 - `/compact`: send `run.start(force_compaction=true)`
-- `/model [provider/]name`: set model directly or open provider/model picker
+- `/model [--session] [provider/]name`: set model directly or open provider/model picker; default persists to config, `--session` applies only to the active runtime/session
+- `/model-session [provider/]name|reset`: alias for session-local model switching; `reset` clears the session override
 - `/fast [on|off|toggle]`: update current model config with `fast`; no argument toggles
 - `/context [brief]`: call `context.inspect`
 - `/skills [query] [all|repo|user] [--reload] [--scope <...>]`: open skills picker

--- a/dev-docs/specs/tui-operation-reference.md
+++ b/dev-docs/specs/tui-operation-reference.md
@@ -16,7 +16,7 @@ Slash commands available in composer:
 
 - `/help`: print command list to log
 - `/compact`: send `run.start(force_compaction=true)`
-- `/model [--session] [provider/]name`: set model directly or open provider/model picker; default persists to config, `--session` applies only to the active runtime/session
+- `/model [--session] [provider/]name`: set model directly or open provider/model picker; default persists to config, `--session` applies only to the active session and is restored on resume
 - `/model-session [provider/]name|reset`: alias for session-local model switching; `reset` clears the session override
 - `/fast [on|off|toggle]`: update current model config with `fast`; no argument toggles
 - `/context [brief]`: call `context.inspect`

--- a/dev-docs/specs/ui-protocol.md
+++ b/dev-docs/specs/ui-protocol.md
@@ -387,6 +387,7 @@ export type ModelListResult = {
   provider: string;
   models: string[]; // ordered for UI display (newest first when release date exists)
   current?: string;
+  source?: "config" | "session"; // where the current model selection is coming from
   details?: Record<string, {
     release_date?: string; // YYYY-MM-DD (if known)
     context_window?: number;
@@ -412,8 +413,10 @@ UI → Runtime request。
 params (example):
 ```ts
 export type ModelSetParams = {
-  name: string;
+  name?: string; // required unless reset=true
   provider?: string; // default: "openai"
+  scope?: "config" | "session"; // default: "config"
+  reset?: boolean; // scope=session only; clears the session override
 };
 ```
 
@@ -422,8 +425,11 @@ result (example):
 export type ModelSetResult = {
   provider: string;
   name: string;
+  source: "config" | "session";
 };
 ```
+
+`scope=config` persists through the config write policy. `scope=session` updates only the active runtime/session override and leaves global/project config untouched; the next run in that session uses the override. `reset=true` with `scope=session` clears the override and returns to the effective config model.
 
 ### 5.10 `tool.call` (optional)
 

--- a/dev-docs/specs/ui-protocol.md
+++ b/dev-docs/specs/ui-protocol.md
@@ -429,7 +429,7 @@ export type ModelSetResult = {
 };
 ```
 
-`scope=config` persists through the config write policy. `scope=session` updates only the active runtime/session override and leaves global/project config untouched; the next run in that session uses the override. `reset=true` with `scope=session` clears the override and returns to the effective config model.
+`scope=config` persists through the config write policy. `scope=session` stores the override in `SessionState.meta.codelia_model_override` for the active session and leaves global/project config untouched; future runs or resumes of that session use the override. If no `session_id` exists yet, runtime keeps the override pending and writes it when the first run creates the session. `reset=true` with `scope=session` clears the session override and returns to the effective config model.
 
 ### 5.10 `tool.call` (optional)
 

--- a/packages/core/src/types/session-store.ts
+++ b/packages/core/src/types/session-store.ts
@@ -17,6 +17,7 @@ export type SessionHeader = {
 		name?: string;
 		reasoning?: string;
 		fast?: boolean;
+		source?: "config" | "session";
 	};
 	prompts?: { system?: string };
 	tools?: { definitions?: ToolDefinition[]; source?: string };

--- a/packages/protocol/src/model.ts
+++ b/packages/protocol/src/model.ts
@@ -16,21 +16,25 @@ export type ModelListResult = {
 	provider: string;
 	models: string[];
 	current?: string;
+	source?: "config" | "session";
 	reasoning?: "low" | "medium" | "high" | "xhigh";
 	fast?: boolean;
 	details?: Record<string, ModelListDetails>;
 };
 
 export type ModelSetParams = {
-	name: string;
+	name?: string;
 	provider?: string;
 	reasoning?: "low" | "medium" | "high" | "xhigh";
 	fast?: boolean;
+	scope?: "config" | "session";
+	reset?: boolean;
 };
 
 export type ModelSetResult = {
 	provider: string;
 	name: string;
+	source: "config" | "session";
 	reasoning?: "low" | "medium" | "high" | "xhigh";
 	fast?: boolean;
 };

--- a/packages/runtime/AGENTS.md
+++ b/packages/runtime/AGENTS.md
@@ -39,7 +39,7 @@ Local `search` tool supports `ddg`/`brave` backends; `brave` reads API key from 
 The defaults are registered in `configRegistry` on the core side, and the runtime uses only the synthesized settings.
 The project settings (`.codelia/config.json`) are read by runtime and synthesized with the global config (CLI is not supported).
 You can override the global config location with `CODELIA_CONFIG_PATH`.
-Get the model list and update the config using RPC `model.list` / `model.set` (model.set recreates the Agent).
+Get the model list and update the model using RPC `model.list` / `model.set` (model.set recreates the Agent). `model.set scope=config` writes through the config policy; `scope=session` changes only `RuntimeState.sessionModelOverride` for the active runtime/session and should report `source=session`.
 `model.list` returns the context window / input/output limit in `include_details=true` (omitted if it cannot be obtained). For static providers, displayed limits follow the merged runtime registry (same precedence as execution), not raw metadata rows.
 `model.list` sorts by `release_date` (newest first when available) and can include normalized cost fields (`cost_per_1m_*_usd`) in details.
 If provider of `model.list` is not specified, the provider of config is given priority and a list is returned.

--- a/packages/runtime/AGENTS.md
+++ b/packages/runtime/AGENTS.md
@@ -39,7 +39,7 @@ Local `search` tool supports `ddg`/`brave` backends; `brave` reads API key from 
 The defaults are registered in `configRegistry` on the core side, and the runtime uses only the synthesized settings.
 The project settings (`.codelia/config.json`) are read by runtime and synthesized with the global config (CLI is not supported).
 You can override the global config location with `CODELIA_CONFIG_PATH`.
-Get the model list and update the model using RPC `model.list` / `model.set` (model.set recreates the Agent). `model.set scope=config` writes through the config policy; `scope=session` changes only `RuntimeState.sessionModelOverride` for the active runtime/session and should report `source=session`.
+Get the model list and update the model using RPC `model.list` / `model.set` (model.set recreates the Agent). `model.set scope=config` writes through the config policy; `scope=session` stores `codelia_model_override` in `SessionState.meta` for the active session, restores it before Agent creation on `run.start session_id=...`, and should report `source=session`.
 `model.list` returns the context window / input/output limit in `include_details=true` (omitted if it cannot be obtained). For static providers, displayed limits follow the merged runtime registry (same precedence as execution), not raw metadata rows.
 `model.list` sorts by `release_date` (newest first when available) and can include normalized cost fields (`cost_per_1m_*_usd`) in details.
 If provider of `model.list` is not specified, the provider of config is given priority and a list is returned.

--- a/packages/runtime/src/agent-factory.ts
+++ b/packages/runtime/src/agent-factory.ts
@@ -32,13 +32,13 @@ import {
 	loadSystemPrompt,
 	readEnvValue,
 	resolveExecutionEnvironmentConfig,
-	resolveModelConfig,
 	resolvePermissionsConfig,
 	resolveReasoningEffort,
 	resolveSearchConfig,
 	resolveSkillsConfig,
 	resolveTextVerbosity,
 } from "./config";
+import { resolveEffectiveModelConfig } from "./effective-model";
 import {
 	appendInitialExecutionEnvironment,
 	buildExecutionEnvironmentContext,
@@ -47,12 +47,12 @@ import {
 import { debugLog, log } from "./logger";
 import type { McpManager, McpOAuthPromptConfig, McpOAuthTokens } from "./mcp";
 import { createMcpOAuthSession } from "./mcp/oauth";
+import { resolveFastMode } from "./model-fast";
 import {
 	resolveAnthropicMaxTokens,
 	resolveAnthropicReasoning,
 	resolveResponsesReasoning,
 } from "./model-reasoning";
-import { resolveFastMode } from "./model-fast";
 import { buildModelRegistry } from "./model-registry";
 import { resolveApprovalModeForRuntime } from "./permissions/approval-mode";
 import {
@@ -698,9 +698,9 @@ export const createAgentFactory = (
 			log(
 				`approval_mode resolved=${approvalModeResolution.approvalMode} source=${approvalModeResolution.source} project=${approvalModeResolution.projectKey}`,
 			);
-			let modelConfig: Awaited<ReturnType<typeof resolveModelConfig>>;
+			let modelConfig: Awaited<ReturnType<typeof resolveEffectiveModelConfig>>;
 			try {
-				modelConfig = await resolveModelConfig(ctx.workingDir);
+				modelConfig = await resolveEffectiveModelConfig(state, ctx.workingDir);
 			} catch (error) {
 				const message = error instanceof Error ? error.message : String(error);
 				throw new Error(message);
@@ -862,6 +862,7 @@ export const createAgentFactory = (
 			}
 			state.currentModelProvider = provider;
 			state.currentModelName = resolvedModelName;
+			state.currentModelSource = modelConfig.source;
 			const modelRegistry = await buildModelRegistry(llm, {
 				strict: provider !== "openrouter",
 			});

--- a/packages/runtime/src/config.ts
+++ b/packages/runtime/src/config.ts
@@ -92,9 +92,7 @@ export const resolveConfigLayers = async (
 	projectConfig: CodeliaConfig | null;
 }> => loadConfigLayers(workingDir);
 
-export const resolveModelConfig = async (
-	workingDir?: string,
-): Promise<{
+export type ResolvedModelConfig = {
 	provider?: string;
 	name?: string;
 	reasoning?: string;
@@ -105,7 +103,11 @@ export const resolveModelConfig = async (
 			websocket_mode?: "off" | "auto" | "on";
 		};
 	};
-}> => {
+};
+
+export const resolveModelConfig = async (
+	workingDir?: string,
+): Promise<ResolvedModelConfig> => {
 	const { globalConfig, projectConfig } = await loadConfigLayers(workingDir);
 	const effective = configRegistry.resolve([globalConfig, projectConfig]);
 	return {

--- a/packages/runtime/src/effective-model.ts
+++ b/packages/runtime/src/effective-model.ts
@@ -6,6 +6,7 @@ import type {
 } from "./runtime-state";
 
 type ReasoningEffort = "low" | "medium" | "high" | "xhigh" | undefined;
+const MODEL_OVERRIDE_SESSION_META_KEY = "codelia_model_override";
 
 export type EffectiveModelConfig = ResolvedModelConfig & {
 	source: RuntimeModelSource;
@@ -59,4 +60,52 @@ export const setSessionModelOverride = (
 
 export const clearSessionModelOverride = (state: RuntimeState): void => {
 	state.sessionModelOverride = null;
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+	typeof value === "object" && value !== null && !Array.isArray(value);
+
+const pickString = (value: unknown): string | undefined =>
+	typeof value === "string" && value.trim() ? value.trim() : undefined;
+
+export const readSessionModelOverride = (
+	meta: Record<string, unknown> | undefined,
+): RuntimeModelOverride | null => {
+	const raw = meta?.[MODEL_OVERRIDE_SESSION_META_KEY];
+	if (!isRecord(raw)) return null;
+	const provider = pickString(raw.provider);
+	const name = pickString(raw.name);
+	const reasoning = pickString(raw.reasoning);
+	if (!provider || !name) return null;
+	return {
+		provider,
+		name,
+		...(reasoning ? { reasoning } : {}),
+		...(typeof raw.fast === "boolean" ? { fast: raw.fast } : {}),
+	};
+};
+
+export const mergeSessionModelOverrideIntoMeta = (
+	meta: Record<string, unknown> | undefined,
+	override: RuntimeModelOverride | null,
+): Record<string, unknown> | undefined => {
+	const nextMeta = meta ? { ...meta } : {};
+	if (override?.provider && override.name) {
+		nextMeta[MODEL_OVERRIDE_SESSION_META_KEY] = {
+			provider: override.provider,
+			name: override.name,
+			...(override.reasoning ? { reasoning: override.reasoning } : {}),
+			...(override.fast !== undefined ? { fast: override.fast } : {}),
+		};
+	} else {
+		delete nextMeta[MODEL_OVERRIDE_SESSION_META_KEY];
+	}
+	return Object.keys(nextMeta).length > 0 ? nextMeta : undefined;
+};
+
+export const applySessionModelOverrideFromMeta = (
+	state: RuntimeState,
+	meta: Record<string, unknown> | undefined,
+): void => {
+	state.sessionModelOverride = readSessionModelOverride(meta);
 };

--- a/packages/runtime/src/effective-model.ts
+++ b/packages/runtime/src/effective-model.ts
@@ -1,0 +1,62 @@
+import { type ResolvedModelConfig, resolveModelConfig } from "./config";
+import type {
+	RuntimeModelOverride,
+	RuntimeModelSource,
+	RuntimeState,
+} from "./runtime-state";
+
+type ReasoningEffort = "low" | "medium" | "high" | "xhigh" | undefined;
+
+export type EffectiveModelConfig = ResolvedModelConfig & {
+	source: RuntimeModelSource;
+};
+
+const mergeModelOverride = (
+	config: ResolvedModelConfig,
+	override: RuntimeModelOverride | null,
+): ResolvedModelConfig => {
+	if (!override) return config;
+	return {
+		...config,
+		provider: override.provider ?? config.provider,
+		name: override.name ?? config.name,
+		reasoning: override.reasoning ?? config.reasoning,
+		fast: override.fast ?? config.fast,
+	};
+};
+
+export const resolveEffectiveModelConfig = async (
+	state: RuntimeState,
+	workingDir?: string,
+): Promise<EffectiveModelConfig> => {
+	const config = await resolveModelConfig(workingDir);
+	const source = state.sessionModelOverride ? "session" : "config";
+	return {
+		...mergeModelOverride(config, state.sessionModelOverride),
+		source,
+	};
+};
+
+export const setSessionModelOverride = (
+	state: RuntimeState,
+	baseConfig: ResolvedModelConfig,
+	next: {
+		provider: string;
+		name: string;
+		reasoning?: ReasoningEffort;
+		fast?: boolean;
+	},
+): ResolvedModelConfig => {
+	const current = mergeModelOverride(baseConfig, state.sessionModelOverride);
+	state.sessionModelOverride = {
+		provider: next.provider,
+		name: next.name,
+		reasoning: next.reasoning ?? current.reasoning,
+		fast: next.fast ?? current.fast,
+	};
+	return mergeModelOverride(baseConfig, state.sessionModelOverride);
+};
+
+export const clearSessionModelOverride = (state: RuntimeState): void => {
+	state.sessionModelOverride = null;
+};

--- a/packages/runtime/src/rpc/handlers.ts
+++ b/packages/runtime/src/rpc/handlers.ts
@@ -64,11 +64,11 @@ import {
 	buildProviderModelList as buildProviderModelListDefault,
 	createModelHandlers,
 } from "./model";
-import { createRunHandlers } from "./run";
 import {
 	buildResumeDiff,
 	hasStructuredResumeContextMeta,
 } from "./resume-context";
+import { createRunHandlers } from "./run";
 import { createShellHandlers } from "./shell";
 import { createSkillsHandlers } from "./skills";
 import { createTaskHandlers } from "./task";
@@ -233,8 +233,10 @@ export const createRuntimeHandlers = ({
 			provider,
 			name: selectedModel,
 		});
+		state.sessionModelOverride = null;
 		state.currentModelProvider = provider;
 		state.currentModelName = selectedModel;
+		state.currentModelSource = "config";
 		state.agent = null;
 		log(
 			`startup onboarding completed: ${provider}/${selectedModel} scope=${modelTarget.scope} path=${modelTarget.path}`,

--- a/packages/runtime/src/rpc/handlers.ts
+++ b/packages/runtime/src/rpc/handlers.ts
@@ -296,6 +296,7 @@ export const createRuntimeHandlers = ({
 	const { handleModelList, handleModelSet } = createModelHandlers({
 		state,
 		log,
+		sessionStateStore,
 	});
 	const { handleContextInspect } = createContextHandlers({
 		state,
@@ -479,6 +480,7 @@ export const createRuntimeHandlers = ({
 				state.sessionId = null;
 				state.sessionMeta = null;
 				state.sessionAppend = null;
+				state.sessionModelOverride = null;
 			}
 			const result: AuthLogoutResult = {
 				ok: true,

--- a/packages/runtime/src/rpc/model.ts
+++ b/packages/runtime/src/rpc/model.ts
@@ -7,6 +7,7 @@ import {
 	type ModelRegistry,
 	resolveModel,
 	resolveProviderModelId,
+	type SessionStateStore,
 } from "@codelia/core";
 import { ModelMetadataServiceImpl } from "@codelia/model-metadata";
 import {
@@ -27,6 +28,7 @@ import {
 } from "../config";
 import {
 	clearSessionModelOverride,
+	mergeSessionModelOverrideIntoMeta,
 	resolveEffectiveModelConfig,
 	setSessionModelOverride,
 } from "../effective-model";
@@ -37,6 +39,7 @@ import { sendError, sendResult } from "./transport";
 export type ModelHandlersDeps = {
 	state: RuntimeState;
 	log: (message: string) => void;
+	sessionStateStore?: SessionStateStore;
 };
 
 type SupportedModelProvider = "openai" | "anthropic" | "openrouter";
@@ -433,10 +436,30 @@ export const buildProviderModelList = async ({
 export const createModelHandlers = ({
 	state,
 	log,
+	sessionStateStore,
 }: ModelHandlersDeps): {
 	handleModelList: (id: string, params: ModelListParams) => Promise<void>;
 	handleModelSet: (id: string, params: ModelSetParams) => Promise<void>;
 } => {
+	const persistSessionModelOverride = async (): Promise<void> => {
+		const sessionId = state.sessionId;
+		const snapshot =
+			sessionId && sessionStateStore
+				? await sessionStateStore.load(sessionId)
+				: null;
+		const nextMeta = mergeSessionModelOverrideIntoMeta(
+			snapshot?.meta ?? state.sessionMeta ?? undefined,
+			state.sessionModelOverride,
+		);
+		state.sessionMeta = nextMeta ?? null;
+		if (!snapshot || !sessionStateStore) return;
+		await sessionStateStore.save({
+			...snapshot,
+			updated_at: new Date().toISOString(),
+			meta: nextMeta,
+		});
+	};
+
 	const handleModelList = async (
 		id: string,
 		params: ModelListParams,
@@ -555,6 +578,7 @@ export const createModelHandlers = ({
 			}
 			try {
 				clearSessionModelOverride(state);
+				await persistSessionModelOverride();
 				const config = await resolveModelConfig(workingDir);
 				const provider = config.provider ?? "openai";
 				const name = config.name;
@@ -646,6 +670,7 @@ export const createModelHandlers = ({
 					...(params.fast !== undefined ? { fast: params.fast } : {}),
 				});
 				clearSessionModelOverride(state);
+				await persistSessionModelOverride();
 			} else {
 				const baseConfig = await resolveModelConfig(workingDir);
 				setSessionModelOverride(state, baseConfig, {
@@ -654,6 +679,7 @@ export const createModelHandlers = ({
 					...(reasoning ? { reasoning } : {}),
 					...(params.fast !== undefined ? { fast: params.fast } : {}),
 				});
+				await persistSessionModelOverride();
 			}
 			state.currentModelProvider = provider;
 			state.currentModelName = name;

--- a/packages/runtime/src/rpc/model.ts
+++ b/packages/runtime/src/rpc/model.ts
@@ -25,6 +25,11 @@ import {
 	resolveReasoningEffort,
 	updateModel,
 } from "../config";
+import {
+	clearSessionModelOverride,
+	resolveEffectiveModelConfig,
+	setSessionModelOverride,
+} from "../effective-model";
 import { resolveFastMode } from "../model-fast";
 import type { RuntimeState } from "../runtime-state";
 import { sendError, sendResult } from "./transport";
@@ -446,11 +451,15 @@ export const createModelHandlers = ({
 			return;
 		}
 		let current: string | undefined;
+		let source: "config" | "session" = "config";
 		let configuredProvider: string | undefined;
 		let configuredReasoning: "low" | "medium" | "high" | "xhigh" | undefined;
 		let configuredFast: boolean | undefined;
 		try {
-			const config = await resolveModelConfig();
+			const workingDir =
+				state.lastUiContext?.cwd ?? state.runtimeWorkingDir ?? undefined;
+			const config = await resolveEffectiveModelConfig(state, workingDir);
+			source = config.source;
 			configuredProvider = config.provider ?? "openai";
 			configuredReasoning = resolveReasoningEffort(config.reasoning);
 			if (!requestedProvider || requestedProvider === configuredProvider) {
@@ -507,6 +516,7 @@ export const createModelHandlers = ({
 			provider,
 			models,
 			current,
+			source,
 			...(configuredReasoning ? { reasoning: configuredReasoning } : {}),
 			...(configuredFast !== undefined ? { fast: configuredFast } : {}),
 			...(details ? { details } : {}),
@@ -523,6 +533,65 @@ export const createModelHandlers = ({
 				code: RPC_ERROR_CODE.RUNTIME_BUSY,
 				message: "runtime busy",
 			});
+			return;
+		}
+		const scope = params?.scope ?? "config";
+		if (scope !== "config" && scope !== "session") {
+			sendError(id, {
+				code: RPC_ERROR_CODE.INVALID_PARAMS,
+				message: `unsupported model scope: ${scope}`,
+			});
+			return;
+		}
+		const workingDir =
+			state.lastUiContext?.cwd ?? state.runtimeWorkingDir ?? process.cwd();
+		if (params?.reset) {
+			if (scope !== "session") {
+				sendError(id, {
+					code: RPC_ERROR_CODE.INVALID_PARAMS,
+					message: "model reset is only supported for session scope",
+				});
+				return;
+			}
+			try {
+				clearSessionModelOverride(state);
+				const config = await resolveModelConfig(workingDir);
+				const provider = config.provider ?? "openai";
+				const name = config.name;
+				if (!name) {
+					sendError(id, {
+						code: RPC_ERROR_CODE.RUNTIME_INTERNAL,
+						message: "configured model name is missing",
+					});
+					return;
+				}
+				state.currentModelProvider = provider;
+				state.currentModelName = name;
+				state.currentModelSource = "config";
+				state.agent = null;
+				const effectiveReasoning = resolveReasoningEffort(config.reasoning);
+				const effectiveFast = isSupportedProvider(provider)
+					? resolveFastMode({
+							provider,
+							model: name,
+							requested: config.fast,
+						}).enabled
+					: false;
+				const result: ModelSetResult = {
+					provider,
+					name,
+					source: "config",
+					...(effectiveReasoning ? { reasoning: effectiveReasoning } : {}),
+					...(config.fast !== undefined ? { fast: effectiveFast } : {}),
+				};
+				sendResult(id, result);
+				log(`model.set reset session override -> ${provider}/${name}`);
+			} catch (error) {
+				sendError(id, {
+					code: RPC_ERROR_CODE.RUNTIME_INTERNAL,
+					message: String(error),
+				});
+			}
 			return;
 		}
 		const provider = params?.provider ?? "openai";
@@ -568,18 +637,32 @@ export const createModelHandlers = ({
 			}
 		}
 		try {
-			const workingDir =
-				state.lastUiContext?.cwd ?? state.runtimeWorkingDir ?? process.cwd();
-			const target = await updateModel(workingDir, {
-				provider,
-				name,
-				...(reasoning ? { reasoning } : {}),
-				...(params.fast !== undefined ? { fast: params.fast } : {}),
-			});
+			let target: Awaited<ReturnType<typeof updateModel>> | null = null;
+			if (scope === "config") {
+				target = await updateModel(workingDir, {
+					provider,
+					name,
+					...(reasoning ? { reasoning } : {}),
+					...(params.fast !== undefined ? { fast: params.fast } : {}),
+				});
+				clearSessionModelOverride(state);
+			} else {
+				const baseConfig = await resolveModelConfig(workingDir);
+				setSessionModelOverride(state, baseConfig, {
+					provider,
+					name,
+					...(reasoning ? { reasoning } : {}),
+					...(params.fast !== undefined ? { fast: params.fast } : {}),
+				});
+			}
 			state.currentModelProvider = provider;
 			state.currentModelName = name;
+			state.currentModelSource = scope;
 			state.agent = null;
-			const updatedConfig = await resolveModelConfig(workingDir);
+			const updatedConfig = await resolveEffectiveModelConfig(
+				state,
+				workingDir,
+			);
 			const effectiveReasoning = resolveReasoningEffort(
 				updatedConfig.reasoning,
 			);
@@ -591,12 +674,17 @@ export const createModelHandlers = ({
 			const result: ModelSetResult = {
 				provider,
 				name,
+				source: scope,
 				...(effectiveReasoning ? { reasoning: effectiveReasoning } : {}),
 				...(updatedConfig.fast !== undefined ? { fast: effectiveFast } : {}),
 			};
 			sendResult(id, result);
+			const persistence =
+				scope === "config" && target
+					? ` scope=${target.scope} path=${target.path}`
+					: " scope=session";
 			log(
-				`model.set ${provider}/${name}${effectiveReasoning ? ` reasoning=${effectiveReasoning}` : ""} scope=${target.scope} path=${target.path}`,
+				`model.set ${provider}/${name}${effectiveReasoning ? ` reasoning=${effectiveReasoning}` : ""}${persistence}`,
 			);
 		} catch (error) {
 			sendError(id, {

--- a/packages/runtime/src/rpc/run.ts
+++ b/packages/runtime/src/rpc/run.ts
@@ -16,7 +16,11 @@ import {
 	type RunStartResult,
 } from "@codelia/protocol";
 import { SERVER_NAME, SERVER_VERSION } from "../constants";
-import { resolveEffectiveModelConfig } from "../effective-model";
+import {
+	applySessionModelOverrideFromMeta,
+	mergeSessionModelOverrideIntoMeta,
+	resolveEffectiveModelConfig,
+} from "../effective-model";
 import type { RuntimeState } from "../runtime-state";
 import {
 	clearTodosForSession,
@@ -304,18 +308,6 @@ export const createRunHandlers = ({
 				return;
 			}
 
-			let runtimeAgent: Agent;
-			try {
-				runtimeAgent = await getAgent();
-			} catch (error) {
-				sendError(id, {
-					code: RPC_ERROR_CODE.RUNTIME_INTERNAL,
-					message: String(error),
-				});
-				return;
-			}
-			normalizeRuntimeAgentHistory("run.start preflight", runtimeAgent);
-
 			const requestedSessionId = params.session_id?.trim() || undefined;
 			let resumeState: SessionState | null = null;
 			const previousSessionId = state.sessionId;
@@ -339,18 +331,8 @@ export const createRunHandlers = ({
 					});
 					return;
 				}
-				await restoreSessionHistoryIntoAgent({
-					runtimeAgent,
-					resumeState,
-					sessionId: requestedSessionId,
-				});
-				sessionId = requestedSessionId;
-				state.sessionId = sessionId;
-				loadedSessionState = true;
-			} else if (
-				state.sessionId &&
-				runtimeAgent.getHistoryMessages().length === 0
-			) {
+				applySessionModelOverrideFromMeta(state, resumeState.meta);
+			} else if (state.sessionId) {
 				try {
 					resumeState = await sessionStateStore.load(state.sessionId);
 				} catch (error) {
@@ -360,6 +342,35 @@ export const createRunHandlers = ({
 					});
 					return;
 				}
+				if (resumeState) {
+					applySessionModelOverrideFromMeta(state, resumeState.meta);
+				}
+			}
+
+			let runtimeAgent: Agent;
+			try {
+				runtimeAgent = await getAgent();
+			} catch (error) {
+				sendError(id, {
+					code: RPC_ERROR_CODE.RUNTIME_INTERNAL,
+					message: String(error),
+				});
+				return;
+			}
+			normalizeRuntimeAgentHistory("run.start preflight", runtimeAgent);
+			if (requestedSessionId && requestedSessionId !== state.sessionId) {
+				await restoreSessionHistoryIntoAgent({
+					runtimeAgent,
+					resumeState: resumeState as SessionState,
+					sessionId: requestedSessionId,
+				});
+				sessionId = requestedSessionId;
+				state.sessionId = sessionId;
+				loadedSessionState = true;
+			} else if (
+				state.sessionId &&
+				runtimeAgent.getHistoryMessages().length === 0
+			) {
 				if (resumeState) {
 					await restoreSessionHistoryIntoAgent({
 						runtimeAgent,
@@ -608,9 +619,17 @@ export const createRunHandlers = ({
 								state.sessionMeta ?? undefined,
 								getTodosForSession(sessionId),
 							);
+							const sessionMetaWithModelOverride =
+								mergeSessionModelOverrideIntoMeta(
+									sessionMeta,
+									state.sessionModelOverride,
+								);
 							const workspaceRoot = resolveSessionWorkspaceRoot(state);
 							const sessionMetaWithWorkspace =
-								mergeWorkspaceRootIntoSessionMeta(sessionMeta, workspaceRoot);
+								mergeWorkspaceRootIntoSessionMeta(
+									sessionMetaWithModelOverride,
+									workspaceRoot,
+								);
 							const sessionMetaWithResumeContext =
 								mergeResumeContextIntoSessionMeta(
 									sessionMetaWithWorkspace,

--- a/packages/runtime/src/rpc/run.ts
+++ b/packages/runtime/src/rpc/run.ts
@@ -15,8 +15,8 @@ import {
 	type RunStartParams,
 	type RunStartResult,
 } from "@codelia/protocol";
-import { resolveModelConfig } from "../config";
 import { SERVER_NAME, SERVER_VERSION } from "../constants";
+import { resolveEffectiveModelConfig } from "../effective-model";
 import type { RuntimeState } from "../runtime-state";
 import {
 	clearTodosForSession,
@@ -25,6 +25,14 @@ import {
 	readTodosFromSessionMeta,
 	setTodosForSession,
 } from "../tools/todo-store";
+import {
+	buildResumeDiff,
+	injectResumeDiffSystemReminder,
+	mergeResumeContextIntoSessionMeta,
+	prependCurrentStartupSystemMessage,
+	stripResumeDiffSystemMessages,
+	stripStartupSystemMessages,
+} from "./resume-context";
 import {
 	formatErrorForDebugLog,
 	isAbortLikeError,
@@ -35,14 +43,6 @@ import {
 	summarizeProviderMeta,
 	summarizeRunEvent,
 } from "./run-debug";
-import {
-	buildResumeDiff,
-	injectResumeDiffSystemReminder,
-	mergeResumeContextIntoSessionMeta,
-	prependCurrentStartupSystemMessage,
-	stripResumeDiffSystemMessages,
-	stripStartupSystemMessages,
-} from "./resume-context";
 import {
 	type NormalizedRunInput,
 	normalizeRunInput,
@@ -520,10 +520,13 @@ export const createRunHandlers = ({
 				invoke_seq: resumeState?.invoke_seq,
 				append: sessionAppend,
 			};
-			let modelConfig: Awaited<ReturnType<typeof resolveModelConfig>> | null =
-				null;
+			let modelConfig: Awaited<
+				ReturnType<typeof resolveEffectiveModelConfig>
+			> | null = null;
 			try {
-				modelConfig = await resolveModelConfig();
+				const workingDir =
+					state.lastUiContext?.cwd ?? state.runtimeWorkingDir ?? undefined;
+				modelConfig = await resolveEffectiveModelConfig(state, workingDir);
 			} catch (error) {
 				log(`session header model config error: ${error}`);
 			}
@@ -540,6 +543,7 @@ export const createRunHandlers = ({
 							provider: modelConfig.provider,
 							name: modelConfig.name,
 							reasoning: modelConfig.reasoning,
+							source: modelConfig.source,
 							...(modelConfig.fast !== undefined
 								? { fast: modelConfig.fast }
 								: {}),

--- a/packages/runtime/src/runtime-state.ts
+++ b/packages/runtime/src/runtime-state.ts
@@ -9,6 +9,15 @@ import type { ApprovalMode, SkillCatalog } from "@codelia/shared-types";
 import type { AgentsResolver } from "./agents";
 import type { SkillsResolver } from "./skills";
 
+export type RuntimeModelSource = "config" | "session";
+
+export type RuntimeModelOverride = {
+	provider?: string;
+	name?: string;
+	reasoning?: string;
+	fast?: boolean;
+};
+
 export class RuntimeState {
 	private runSeq = new Map<string, number>();
 	private uiRequestCounter = 0;
@@ -44,6 +53,8 @@ export class RuntimeState {
 	approvalMode: ApprovalMode | null = null;
 	currentModelProvider: string | null = null;
 	currentModelName: string | null = null;
+	currentModelSource: RuntimeModelSource | null = null;
+	sessionModelOverride: RuntimeModelOverride | null = null;
 	diagnosticsEnabled = false;
 
 	nextRunId(): string {

--- a/packages/runtime/tests/model-state-sync.test.ts
+++ b/packages/runtime/tests/model-state-sync.test.ts
@@ -2,7 +2,12 @@ import { describe, expect, test } from "bun:test";
 import { promises as fs } from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import type { Agent } from "@codelia/core";
+import type {
+	Agent,
+	BaseMessage,
+	SessionState,
+	SessionStateStore,
+} from "@codelia/core";
 import type { RpcMessage, RpcRequest, RpcResponse } from "@codelia/protocol";
 import { createRuntimeHandlers } from "../src/rpc/handlers";
 import { RuntimeState } from "../src/runtime-state";
@@ -133,6 +138,52 @@ const withTempEnv = async () => {
 			await fs.rm(tempRoot, { recursive: true, force: true });
 		},
 	};
+};
+
+const createSessionState = (
+	sessionId: string,
+	meta?: Record<string, unknown>,
+): SessionState => ({
+	schema_version: 1,
+	session_id: sessionId,
+	updated_at: new Date().toISOString(),
+	messages: [],
+	meta,
+});
+
+const createSessionStateStore = (
+	map: Map<string, SessionState>,
+): SessionStateStore => ({
+	load: async (sessionId) => map.get(sessionId) ?? null,
+	save: async (state) => {
+		map.set(state.session_id, state);
+	},
+	list: async () => [],
+});
+
+const createInstantAgent = (): Agent => {
+	let messages: BaseMessage[] = [];
+	const runStream = async function* () {
+		yield { type: "final" as const, content: "ok" };
+	};
+	const mock = {
+		runStream,
+		getContextLeftPercent: () => null,
+		getUsageSummary: () => ({
+			total_calls: 0,
+			total_tokens: 0,
+			total_input_tokens: 0,
+			total_output_tokens: 0,
+			total_cached_input_tokens: 0,
+			total_cache_creation_tokens: 0,
+			by_model: {},
+		}),
+		getHistoryMessages: () => messages,
+		replaceHistoryMessages: (next: BaseMessage[]) => {
+			messages = next;
+		},
+	};
+	return mock as unknown as Agent;
 };
 
 describe("model state sync", () => {
@@ -269,6 +320,133 @@ describe("model state sync", () => {
 			expect(state.currentModelName).toBe("gpt-5");
 			expect(state.currentModelSource).toBe("config");
 			expect(state.sessionModelOverride).toBeNull();
+		} finally {
+			capture.stop();
+			await env.cleanup();
+		}
+	});
+
+	test("model.set persists current-session model override in session state", async () => {
+		const env = await withTempEnv();
+		const capture = createStdoutCapture();
+		const sessionStates = new Map<string, SessionState>();
+		sessionStates.set(
+			"session-a",
+			createSessionState("session-a", { existing: true }),
+		);
+		capture.start();
+		try {
+			const state = new RuntimeState();
+			state.sessionId = "session-a";
+			state.sessionMeta = { existing: true };
+			state.lastUiContext = {
+				cwd: env.projectDir,
+				workspace_root: env.projectDir,
+			};
+			state.runtimeWorkingDir = env.projectDir;
+			const handlers = createRuntimeHandlers({
+				state,
+				getAgent: async () => ({}) as Agent,
+				log: () => {},
+				sessionStateStore: createSessionStateStore(sessionStates),
+			});
+
+			handlers.processMessage({
+				jsonrpc: "2.0",
+				id: "model-session-persist-1",
+				method: "model.set",
+				params: {
+					provider: "openai",
+					name: "gpt-5.3-codex",
+					scope: "session",
+					fast: true,
+				},
+			} satisfies RpcRequest);
+			const response = await capture.waitForResponse("model-session-persist-1");
+			expect((response as { error?: unknown }).error).toBeUndefined();
+			expect(sessionStates.get("session-a")?.meta).toMatchObject({
+				existing: true,
+				codelia_model_override: {
+					provider: "openai",
+					name: "gpt-5.3-codex",
+					fast: true,
+				},
+			});
+
+			handlers.processMessage({
+				jsonrpc: "2.0",
+				id: "model-session-persist-reset-1",
+				method: "model.set",
+				params: {
+					scope: "session",
+					reset: true,
+				},
+			} satisfies RpcRequest);
+			const resetResponse = await capture.waitForResponse(
+				"model-session-persist-reset-1",
+			);
+			expect((resetResponse as { error?: unknown }).error).toBeUndefined();
+			expect(sessionStates.get("session-a")?.meta).toEqual({ existing: true });
+		} finally {
+			capture.stop();
+			await env.cleanup();
+		}
+	});
+
+	test("run.start restores persisted session model override before creating agent", async () => {
+		const env = await withTempEnv();
+		const capture = createStdoutCapture();
+		const sessionStates = new Map<string, SessionState>();
+		sessionStates.set(
+			"session-b",
+			createSessionState("session-b", {
+				codelia_model_override: {
+					provider: "openai",
+					name: "gpt-5.3-codex",
+					reasoning: "high",
+				},
+			}),
+		);
+		let overrideAtAgentCreation: unknown;
+		capture.start();
+		try {
+			const state = new RuntimeState();
+			state.lastUiContext = {
+				cwd: env.projectDir,
+				workspace_root: env.projectDir,
+			};
+			state.runtimeWorkingDir = env.projectDir;
+			const handlers = createRuntimeHandlers({
+				state,
+				getAgent: async () => {
+					overrideAtAgentCreation = state.sessionModelOverride;
+					return createInstantAgent();
+				},
+				log: () => {},
+				sessionStateStore: createSessionStateStore(sessionStates),
+			});
+
+			handlers.processMessage({
+				jsonrpc: "2.0",
+				id: "run-restore-model-1",
+				method: "run.start",
+				params: {
+					session_id: "session-b",
+					input: { type: "text", text: "hello" },
+				},
+			} satisfies RpcRequest);
+			const response = await capture.waitForResponse("run-restore-model-1");
+			expect((response as { error?: unknown }).error).toBeUndefined();
+			expect(overrideAtAgentCreation).toEqual({
+				provider: "openai",
+				name: "gpt-5.3-codex",
+				reasoning: "high",
+			});
+			await waitFor(
+				() =>
+					sessionStates.get("session-b")?.meta?.codelia_model_override !==
+					undefined,
+			);
 		} finally {
 			capture.stop();
 			await env.cleanup();

--- a/packages/runtime/tests/model-state-sync.test.ts
+++ b/packages/runtime/tests/model-state-sync.test.ts
@@ -121,6 +121,7 @@ const withTempEnv = async () => {
 
 	return {
 		projectDir,
+		configPath,
 		async cleanup() {
 			for (const [key, value] of envSnapshot) {
 				if (value === undefined) {
@@ -169,10 +170,105 @@ describe("model state sync", () => {
 			expect(response.result).toMatchObject({
 				provider: "openai",
 				name: "gpt-5.3-codex",
+				source: "config",
 			});
 			expect(state.currentModelProvider).toBe("openai");
 			expect(state.currentModelName).toBe("gpt-5.3-codex");
 			expect(state.agent).toBeNull();
+		} finally {
+			capture.stop();
+			await env.cleanup();
+		}
+	});
+
+	test("model.set can switch models for the current session without writing config", async () => {
+		const env = await withTempEnv();
+		const capture = createStdoutCapture();
+		capture.start();
+		try {
+			const state = new RuntimeState();
+			state.lastUiContext = {
+				cwd: env.projectDir,
+				workspace_root: env.projectDir,
+			};
+			state.runtimeWorkingDir = env.projectDir;
+			state.currentModelProvider = "openai";
+			state.currentModelName = "gpt-5";
+			const handlers = createRuntimeHandlers({
+				state,
+				getAgent: async () => ({}) as Agent,
+				log: () => {},
+			});
+
+			handlers.processMessage({
+				jsonrpc: "2.0",
+				id: "model-session-set-1",
+				method: "model.set",
+				params: {
+					provider: "openai",
+					name: "gpt-5.3-codex",
+					reasoning: "high",
+					scope: "session",
+				},
+			} satisfies RpcRequest);
+			const sessionResponse = await capture.waitForResponse(
+				"model-session-set-1",
+			);
+			expect((sessionResponse as { error?: unknown }).error).toBeUndefined();
+			expect(sessionResponse.result).toMatchObject({
+				provider: "openai",
+				name: "gpt-5.3-codex",
+				reasoning: "high",
+				source: "session",
+			});
+			expect(state.currentModelProvider).toBe("openai");
+			expect(state.currentModelName).toBe("gpt-5.3-codex");
+			expect(state.currentModelSource).toBe("session");
+
+			const storedConfig = JSON.parse(
+				await fs.readFile(env.configPath, "utf8"),
+			) as { model?: { name?: string } };
+			expect(storedConfig.model?.name).toBe("gpt-5");
+
+			handlers.processMessage({
+				jsonrpc: "2.0",
+				id: "model-session-list-1",
+				method: "model.list",
+				params: {
+					provider: "openai",
+				},
+			} satisfies RpcRequest);
+			const listResponse = await capture.waitForResponse(
+				"model-session-list-1",
+			);
+			expect(listResponse.result).toMatchObject({
+				provider: "openai",
+				current: "gpt-5.3-codex",
+				reasoning: "high",
+				source: "session",
+			});
+
+			handlers.processMessage({
+				jsonrpc: "2.0",
+				id: "model-session-reset-1",
+				method: "model.set",
+				params: {
+					scope: "session",
+					reset: true,
+				},
+			} satisfies RpcRequest);
+			const resetResponse = await capture.waitForResponse(
+				"model-session-reset-1",
+			);
+			expect(resetResponse.result).toMatchObject({
+				provider: "openai",
+				name: "gpt-5",
+				source: "config",
+			});
+			expect(state.currentModelProvider).toBe("openai");
+			expect(state.currentModelName).toBe("gpt-5");
+			expect(state.currentModelSource).toBe("config");
+			expect(state.sessionModelOverride).toBeNull();
 		} finally {
 			capture.stop();
 			await env.cleanup();


### PR DESCRIPTION
## Summary

- Add `model.set` support for `scope=config|session` plus session reset semantics.
- Keep TUI `/model` config-persisting while adding `/model --session` and `/model-session` for session-local switching.
- Render session-local model state as `model~:` and fast mode as `⚡` in the TUI status line.
- Document the protocol, config write policy, and runtime/TUI behavior.

## Validation

- `bun test packages/runtime/tests/model-state-sync.test.ts`
- `cargo test --manifest-path crates/tui/Cargo.toml`
- `bun run typecheck`
- targeted `bunx biome check ...`
- `git diff --check`

Note: full `bun run check` still reports pre-existing unrelated Biome issues outside this change.