### PR TITLE
[codex] Add Claude Opus 4.8 support

### DIFF
--- a/dev-docs/specs/model-parameter-ui.md
+++ b/dev-docs/specs/model-parameter-ui.md
@@ -46,6 +46,7 @@ Runtime then maps preset id to provider request fields (`thinking` + `thinking.b
 
 The Anthropic table must include all ids from `packages/core/src/models/anthropic.ts`:
 
+- `claude-opus-4-8`
 - `claude-opus-4-7`
 - `claude-opus-4-6`
 - `claude-opus-4-5`

--- a/packages/core/src/models/AGENTS.md
+++ b/packages/core/src/models/AGENTS.md
@@ -11,10 +11,11 @@ The model list is a snapshot, so check the update date and review it regularly.
 - Use `supportsFast: true` only for model ids that support the provider-specific fast path. Runtime maps that flag per provider (for example OpenAI priority service tier, Anthropic fast mode) and leaves unsupported models disabled even when `model.fast` is configured.
 - A model is usable only when the effective spec has a positive context budget (`maxInputTokens` or `contextWindow`). If metadata can be missing for a new/latest model that should still work, put the required limits in the static `ModelSpec`.
 
-## Anthropic Claude Opus 4.7
+## Anthropic Claude Opus 4.8 / 4.7
 
+- `claude-opus-4-8` is available in the static Anthropic registry with 1M context, 128k max output tokens, and Anthropic fast mode support.
 - `claude-opus-4-7` is available in the static Anthropic registry with 1M context and 128k max output tokens.
-- Anthropic Opus 4.7 uses adaptive thinking plus `output_config.effort`; do not route it through legacy extended thinking budget requests.
+- Anthropic Opus 4.8 and 4.7 use adaptive thinking plus `output_config.effort`; do not route them through legacy extended thinking budget requests.
 
 ## OpenAI GPT-5.5
 

--- a/packages/core/src/models/anthropic.ts
+++ b/packages/core/src/models/anthropic.ts
@@ -9,6 +9,14 @@ export const ANTHROPIC_MODELS: ModelSpec[] = [
 		aliases: ["default"],
 	},
 	{
+		id: "claude-opus-4-8",
+		provider: "anthropic",
+		contextWindow: 1_000_000,
+		maxInputTokens: 1_000_000,
+		maxOutputTokens: 128_000,
+		supportsFast: true,
+	},
+	{
 		id: "claude-opus-4-7",
 		provider: "anthropic",
 		contextWindow: 1_000_000,

--- a/packages/runtime/src/model-reasoning.ts
+++ b/packages/runtime/src/model-reasoning.ts
@@ -77,6 +77,15 @@ const ANTHROPIC_MAX_TOKENS_FALLBACK_HEADROOM = 4_096;
 const ANTHROPIC_REASONING_MODEL_TABLE: Readonly<
 	Record<string, AnthropicReasoningModelProfile>
 > = {
+	"claude-opus-4-8": {
+		supportedLevels: ["low", "medium", "high", "xhigh"],
+		budgetPresetByLevel: {
+			low: "reasoning_low",
+			medium: "reasoning_medium",
+			high: "reasoning_high",
+			xhigh: "reasoning_xhigh",
+		},
+	},
 	"claude-opus-4-7": {
 		supportedLevels: ["low", "medium", "high", "xhigh"],
 		budgetPresetByLevel: {
@@ -158,7 +167,10 @@ const ANTHROPIC_REASONING_MODEL_TABLE: Readonly<
 	},
 };
 
-const ANTHROPIC_ADAPTIVE_THINKING_MODELS = new Set<string>(["claude-opus-4-7"]);
+const ANTHROPIC_ADAPTIVE_THINKING_MODELS = new Set<string>([
+	"claude-opus-4-8",
+	"claude-opus-4-7",
+]);
 
 const toAnthropicOutputEffort = (
 	level: CanonicalReasoningLevel,

--- a/packages/runtime/tests/model-fast.test.ts
+++ b/packages/runtime/tests/model-fast.test.ts
@@ -44,6 +44,13 @@ describe("model fast mode resolution", () => {
 		expect(
 			resolveFastMode({
 				provider: "anthropic",
+				model: "claude-opus-4-8",
+				requested: true,
+			}),
+		).toEqual({ enabled: true, provider: "anthropic", fastMode: true });
+		expect(
+			resolveFastMode({
+				provider: "anthropic",
 				model: "claude-opus-4-7",
 				requested: true,
 			}),

--- a/packages/runtime/tests/model-reasoning.test.ts
+++ b/packages/runtime/tests/model-reasoning.test.ts
@@ -55,6 +55,18 @@ describe("model reasoning mapping", () => {
 		expect(mapped.usedFallbackModelProfile).toBe(false);
 	});
 
+	test("maps Claude Opus 4.8 to adaptive thinking and output effort", () => {
+		const mapped = resolveAnthropicReasoning({
+			model: "claude-opus-4-8",
+			requested: "high",
+		});
+		expect(mapped.applied).toBe("high");
+		expect(mapped.budgetPreset).toBe("reasoning_high");
+		expect(mapped.thinking).toEqual({ type: "adaptive" });
+		expect(mapped.outputConfig).toEqual({ effort: "high" });
+		expect(mapped.usedFallbackModelProfile).toBe(false);
+	});
+
 	test("uses conservative fallback profile for unknown anthropic model", () => {
 		const missing: string[] = [];
 		const mapped = resolveAnthropicReasoning({


### PR DESCRIPTION
## Summary
- add Anthropic claude-opus-4-8 to the static model registry with 1M context, 128k output, and fast mode support
- route Opus 4.8 through adaptive thinking plus output_config.effort instead of legacy thinking budgets
- update focused tests and model reasoning docs/agent notes

## Validation
- bun x biome format --write packages/core/src/models/anthropic.ts packages/runtime/src/model-reasoning.ts packages/runtime/tests/model-reasoning.test.ts packages/runtime/tests/model-fast.test.ts dev-docs/specs/model-parameter-ui.md packages/core/src/models/AGENTS.md
- bun test packages/runtime/tests/model-reasoning.test.ts packages/runtime/tests/model-fast.test.ts packages/runtime/tests/model-list-static.test.ts
- bun run --filter @codelia/runtime typecheck
- bun run --filter @codelia/core typecheck